### PR TITLE
Class from jsx

### DIFF
--- a/lib/acorn.js
+++ b/lib/acorn.js
@@ -1,0 +1,14 @@
+'use babel'
+
+const acorn = require('acorn-jsx');
+
+const defaultAcornOptions = {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    locations: true,
+    plugins: { jsx: true }
+}
+
+export const parse = (input) => {
+  return acorn.parse(input, defaultAcornOptions)
+}

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -72,6 +72,19 @@ class FancyReact {
 
       console.log(inputText)
       const result = genReact(inputText, bufferPosition)
+
+      const componentDetails = pathFuncs.componentDetails(
+        projectRoot,
+        result.componentName)
+
+      if (!fs.existsSync(componentDetails.folderPath)) {
+        pathEnv.createComponentFolder(componentDetails)
+      }
+
+      atom.workspace.open(componentDetails.componentPath).then(editor => {
+        editor.setText(result.content)
+      })
+
       console.dir(result)
 
     }

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const pathEnv = require('./path-env');
 const pathFuncs = require('./path-funcs');
 const testContent = require('./test-content');
+const genReact = require('./react-content').generate;
 
 class FancyReact {
 
@@ -13,7 +14,7 @@ class FancyReact {
         this.subscriptions = null;
     }
 
-    activate(state) {
+    activate(/*state*/) {
         // this.modalPanel = atom.workspace.addModalPanel({
         //     item: this.fancyReactView.getElement(),
         //     visible: false
@@ -24,6 +25,7 @@ class FancyReact {
 
         // Register command that toggles this view
         this.subscriptions.add(atom.commands.add('atom-workspace', {
+            'fancy-react:tests': () => this.tests(),
             'fancy-react:generate': () => this.generate()
         }));
     }
@@ -39,7 +41,7 @@ class FancyReact {
         };
     }
 
-    generate() {
+    tests() {
         const editor = atom.workspace.getActivePaneItem()
 
         const inputFilePath = editor.getPath()
@@ -57,6 +59,20 @@ class FancyReact {
           const testFileContent = testContent.generate(inputText, existingText, inputModulePath)
           editor.setText(testFileContent)
         })
+    }
+
+    generate() {
+      const editor = atom.workspace.getActivePaneItem()
+
+      const inputFilePath = editor.getPath()
+      const projectRoot = pathEnv.getProjectRoot(inputFilePath)
+      const inputText = editor.getText()
+      const bufferPosition = editor.getCursorBufferPosition()
+      console.dir(bufferPosition)
+
+      console.log(inputText)
+      const result = genReact(inputText, bufferPosition)
+      console.dir(result)
 
     }
 

--- a/lib/js-gen.js
+++ b/lib/js-gen.js
@@ -1,0 +1,10 @@
+'use babel'
+
+const astring = require('astring').generate;
+
+export const genJs = (estree) => {
+  return astring(estree, { indent: '  ' })
+}
+export const genJsList = (estreeList) => {
+  return estreeList.map(genJs).join('\n')
+}

--- a/lib/node-ops.js
+++ b/lib/node-ops.js
@@ -1,8 +1,10 @@
 'use babel'
 
-const singleNodesToSearch =
-  ['declaration', 'id', 'init', 'body', 'expression', 'left', 'right']
-const multiNodesToSearch = ['declarations']
+const singleNodesToSearch = [
+  'declaration', 'id', 'init', 'body', 'expression',
+  'left', 'right', 'value', 'argument', 'openingElement'
+]
+const multiNodesToSearch = ['declarations', 'body']
 
 export const searchByType = (node, type) => {
   return searchBy(node, byType(type))
@@ -39,7 +41,7 @@ export const searchBy = (currentNode, tester) => {
     } else {
       const multiMatch = multiNodesToSearch.map(s => {
         const nextChild = currentNode[s]
-        if (nextChild) {
+        if (nextChild && nextChild.find) {
           return nextChild.find(d => {
             return searchBy(d, tester)
           })
@@ -53,6 +55,31 @@ export const searchBy = (currentNode, tester) => {
   }
 }
 
+export const searchByLocation = (node, point) => {
+  return searchBy(node, byLocation(point))
+}
+export const searchByLocationAndType = (node, point, type) => {
+  const bl = byLocation(point)
+  const bt = byType(type)
+  return searchBy(node, (n) => bt(n) && bl(n))
+}
+
+const pointAfter = (p, a) => {
+  return p && a &&
+    ((p.line === a.line && p.column > a.column) || (p.line > a.line))
+}
+
+const pointWithin = (p, a, b) => {
+  return pointAfter(p, a) && pointAfter(b, p)
+}
+export const byLocation = (point) => {
+  return (n) => {
+    if (!point || !n || !n.loc) { return false }
+    const start = n.loc.start
+    const end = n.loc.end
+    return pointWithin(point, start, end)
+  }
+}
 export const byType = (type) => {
   return (n) => {
     return n.type === type;

--- a/lib/path-env.js
+++ b/lib/path-env.js
@@ -15,15 +15,28 @@ const getTestFilePath = (sourceFile) => {
 }
 
 const ensureFolderExists = (pathToCheck) => {
-  const dirPathToCheck = path.dirname(pathToCheck)
 
-  if (!fs.existsSync(dirPathToCheck)) {
-    mkdirp.sync(dirPathToCheck)
+  if (!fs.existsSync(pathToCheck)) {
+    mkdirp.sync(pathToCheck)
   }
+}
+
+const ensureFileExists = (pathToCheck) => {
+
+  if (!fs.existsSync(pathToCheck)) {
+    fs.closeSync(fs.openSync(pathToCheck, 'w'))
+  }
+}
+
+const createComponentFolder = (componentDetails) => {
+  ensureFolderExists(componentDetails.folderPath)
+  ensureFileExists(componentDetails.stylesPath)
+  ensureFileExists(componentDetails.componentPath)
 }
 
 module.exports = {
   getTestFilePath,
   ensureFolderExists,
-  getProjectRoot
+  getProjectRoot,
+  createComponentFolder
 }

--- a/lib/path-funcs.js
+++ b/lib/path-funcs.js
@@ -49,11 +49,26 @@ const sourcePathWithinSrc = (sourceFileWithinProject) => {
 
 const moduleName = path.basename
 
+const componentDetails = (projectRoot, componentName) => {
+  const folderPath = `${projectRoot}/client/src/components/${componentName}`
+  const componentPath = `${folderPath}/${componentName}.js`
+  const stylesPath = `${folderPath}/${componentName}.scss`
+
+  return {
+    projectRoot,
+    componentName,
+    folderPath,
+    componentPath,
+    stylesPath
+  }
+}
+
 module.exports = {
   findProjectFor,
   sourceFileToTestFile,
   fullPathToProjectPath,
   sourceFileToModulePath,
   sourcePathWithinSrc,
-  moduleName
+  moduleName,
+  componentDetails
 }

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -1,14 +1,18 @@
 'use babel'
 
+const e = require('estree-builder');
+
 import { parse } from './acorn'
 import { searchByLocationAndType } from './node-ops'
 
-import { genJs, genJsList } from './js-gen'
+import { genJsList } from './js-gen'
 import {
   buildImportStmts,
   buildClass,
   raw,
-  fnArgs
+  fnArgs,
+  dot,
+  assign
 } from './tree-builders'
 
 export const generate = (inputText, point) => {
@@ -18,7 +22,7 @@ export const generate = (inputText, point) => {
     // Note difference between Point and Position
     { line: point.row + 1, column: point.column },
     'JSXOpeningElement')
-  console.dir(tree)
+  console.dir(selected)
 
   const componentName = selected.name.name
 
@@ -31,7 +35,7 @@ export const generate = (inputText, point) => {
   }
 }
 
-export const generateImports = (jsxNode) => {
+export const generateImports = () => {
   const namedImports = [{
     react: ['Component']
   }]
@@ -49,6 +53,17 @@ export const generateComponents = (jsxNode) => {
   const classDecl = buildClass(className, 'Component', {
     render: fnArgs([])
   })
+
+  const defProps = generateProps(className, jsxNode.attributes)
+
   const defExport = raw(`export default ${className}`)
-  return [classDecl, defExport]
+  return [classDecl, defProps, defExport]
+}
+
+const generateProps = (className, attributeNodes) => {
+  const propObject = {}
+  attributeNodes.forEach(a => {
+    propObject[a.name.name] = dot(dot(e.id('PropTypes'), 'object'), 'isRequired')
+  })
+  return assign(dot(e.id(className), 'propTypes'), e.object(propObject))
 }

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -51,13 +51,26 @@ export const generateComponents = (jsxNode) => {
   const className = jsxNode.name.name
 
   const classDecl = buildClass(className, 'Component', {
-    render: fnArgs([])
+    render: generateRender(jsxNode.attributes)
   })
 
   const defProps = generateProps(className, jsxNode.attributes)
 
   const defExport = raw(`export default ${className}`)
   return [classDecl, defProps, defExport]
+}
+
+const generateRender = (attributeNodes) => {
+  const propVars = attributeNodes.map(a => {
+    return e.id(a.name.name)
+  })
+  const objPattern = e('obj-pattern', propVars)
+  const thisDotProps = dot(e.this(), 'props')
+  return fnArgs(
+    [],
+    e.var(objPattern, thisDotProps),
+    e.return(e.id('(\n    )'))
+  )
 }
 
 const generateProps = (className, attributeNodes) => {

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -26,7 +26,7 @@ export const generate = (inputText, point) => {
 
   const componentName = selected.name.name
 
-  const importStmts = generateImports(selected)
+  const importStmts = generateImports(componentName)
   const declarationStmts = generateComponents(selected)
 
   return {
@@ -35,23 +35,24 @@ export const generate = (inputText, point) => {
   }
 }
 
-export const generateImports = () => {
-  const namedImports = [{
+export const generateImports = (componentName) => {
+  const namedImports = {
     react: ['Component']
-  }]
-  const defaultImports = [{
+  }
+  const defaultImports = {
     react: 'React',
     'prop-types': 'PropTypes'
-  }]
+  }
+  defaultImports[`./${componentName}.scss`] = 'styles'
 
-  return buildImportStmts(namedImports, defaultImports)
+  return buildImportStmts([namedImports], [defaultImports])
 }
 
 export const generateComponents = (jsxNode) => {
   const className = jsxNode.name.name
 
   const classDecl = buildClass(className, 'Component', {
-    render: generateRender(jsxNode.attributes)
+    render: generateRender(className, jsxNode.attributes)
   })
 
   const defProps = generateProps(className, jsxNode.attributes)
@@ -60,7 +61,7 @@ export const generateComponents = (jsxNode) => {
   return [classDecl, defProps, defExport]
 }
 
-const generateRender = (attributeNodes) => {
+const generateRender = (className, attributeNodes) => {
   const propVars = attributeNodes.map(a => {
     return e.id(a.name.name)
   })
@@ -69,7 +70,11 @@ const generateRender = (attributeNodes) => {
   return fnArgs(
     [],
     e.var(objPattern, thisDotProps),
-    e.return(e.id('(\n    )'))
+    e.return(e.id(`(
+      <div>
+        Here is a '${className}'
+      </div>
+    )`))
   )
 }
 

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -17,17 +17,18 @@ import {
 
 export const generate = (inputText, point) => {
   const tree = parse(inputText)
-  const selected = searchByLocationAndType(
+  const jsxBlock = searchByLocationAndType(
     tree,
     // Note difference between Point and Position
     { line: point.row + 1, column: point.column },
-    'JSXOpeningElement')
-  console.dir(selected)
+    'JSXElement')
+  //console.dir(selected)
+  const jsxOpening = jsxBlock.openingElement
 
-  const componentName = selected.name.name
+  const componentName = jsxOpening.name.name
 
   const importStmts = generateImports(componentName)
-  const declarationStmts = generateComponents(selected)
+  const declarationStmts = generateComponents(jsxOpening)
 
   return {
     content: genJsList(importStmts.concat(declarationStmts)),

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -3,6 +3,14 @@
 import { parse } from './acorn'
 import { searchByLocationAndType } from './node-ops'
 
+import { genJs, genJsList } from './js-gen'
+import {
+  buildImportStmts,
+  buildClass,
+  raw,
+  fnArgs
+} from './tree-builders'
+
 export const generate = (inputText, point) => {
   const tree = parse(inputText)
   const selected = searchByLocationAndType(
@@ -12,5 +20,35 @@ export const generate = (inputText, point) => {
     'JSXOpeningElement')
   console.dir(tree)
 
-  return selected
+  const componentName = selected.name.name
+
+  const importStmts = generateImports(selected)
+  const declarationStmts = generateComponents(selected)
+
+  return {
+    content: genJsList(importStmts.concat(declarationStmts)),
+    componentName
+  }
+}
+
+export const generateImports = (jsxNode) => {
+  const namedImports = [{
+    react: ['Component']
+  }]
+  const defaultImports = [{
+    react: 'React',
+    'prop-types': 'PropTypes'
+  }]
+
+  return buildImportStmts(namedImports, defaultImports)
+}
+
+export const generateComponents = (jsxNode) => {
+  const className = jsxNode.name.name
+
+  const classDecl = buildClass(className, 'Component', {
+    render: fnArgs([])
+  })
+  const defExport = raw(`export default ${className}`)
+  return [classDecl, defExport]
 }

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -1,0 +1,16 @@
+'use babel'
+
+import { parse } from './acorn'
+import { searchByLocationAndType } from './node-ops'
+
+export const generate = (inputText, point) => {
+  const tree = parse(inputText)
+  const selected = searchByLocationAndType(
+    tree,
+    // Note difference between Point and Position
+    { line: point.row + 1, column: point.column },
+    'JSXOpeningElement')
+  console.dir(tree)
+
+  return selected
+}

--- a/lib/test-content-resources.js
+++ b/lib/test-content-resources.js
@@ -1,11 +1,5 @@
 'use babel'
 
-export const acornOptions = {
-    sourceType: 'module',
-    ecmaVersion: 6,
-    plugins: { jsx: true }
-}
-
 export const reactEnzymeChaiHeader =
 `import React from 'react'
 import { shallow } from 'enzyme'

--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -1,10 +1,10 @@
 'use babel'
 
-const acorn = require('acorn-jsx');
 const astring = require('astring').generate;
 const e = require('estree-builder');
 const R = require('ramda');
 
+import { parse } from './acorn'
 import { noNulls } from './utils'
 import {
   callFn,
@@ -16,7 +16,6 @@ import {
   buildItBlock,
   buildImportStmts
 } from './tree-builders'
-const res = require('./test-content-resources')
 const {
   searchByType,
   byType,
@@ -38,8 +37,10 @@ export const generate = (inputText, existingText, inputModulePath) => {
 
   if (!inputText) { return '' }
 
-  const inputAST = acorn.parse(inputText, res.acornOptions)
+  const inputAST = parse(inputText)
   const inputNodes = inputAST.body
+  const namedExports = nodes.filter(byType("ExportNamedDeclaration"))
+  // const namedExportNames = namedExports.map(findExportName)
 
   // Grab the top level export statements
   const namedExportNodes = inputNodes.filter(byType("ExportNamedDeclaration"))

--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -1,6 +1,5 @@
 'use babel'
 
-const astring = require('astring').generate;
 const e = require('estree-builder');
 const R = require('ramda');
 
@@ -26,12 +25,7 @@ const {
   searchForSuite
 } = require('./node-ops')
 
-export const genJs = (estree) => {
-  return astring(estree, { indent: '  ' })
-}
-export const genJsList = (estreeList) => {
-  return estreeList.map(genJs).join('\n')
-}
+const { genJs, genJsList } = require('./js-gen')
 
 export const generate = (inputText, existingText, inputModulePath) => {
 
@@ -74,7 +68,12 @@ export const generate = (inputText, existingText, inputModulePath) => {
   console.dir(existingTopLevelSuites)
   const mergedSuites = mergeSuites(existingTopLevelSuites, exportSuiteTrees)
 
-  const importStmts = buildImportStmts(exportSuiteTrees)
+  const namedImportMaps = noNulls(exportSuiteTrees
+    .map(t => t.namedDepImports))
+  const defaultImportMaps = noNulls(exportSuiteTrees
+    .map(t => t.defaultDepImports))
+
+  const importStmts = buildImportStmts(namedImportMaps, defaultImportMaps, exportSuiteTrees)
 
   const namedExportSuites =
     mergedSuites.map(genJs).join('\n')

--- a/lib/tree-builders.js
+++ b/lib/tree-builders.js
@@ -116,6 +116,10 @@ export const dot = (target, prop) => {
   return e('.', target, e.id(prop))
 }
 
+export const assign = (left, right) => {
+  return e('=', left, right)
+}
+
 export const fn = (...body) => {
   return e.function([], noNulls(body))
 }

--- a/lib/tree-builders.js
+++ b/lib/tree-builders.js
@@ -48,28 +48,40 @@ export const buildItBlock = (desc, body) => {
     [e.string(desc), e.function([], body)])
 }
 
-export const buildImportStmts = (exportSuiteTrees) => {
+export const buildClass = (className, superClass, methods) => {
+  const methodDefs = Object.keys(methods).map(k => {
+    const def = methods[k]
+    return e.method(k, def)
+  })
+  return e.class(className, superClass, methodDefs)
+}
+/*
+namedImportMaps = [{
+  importPath: ['named1', 'named2']
+}]
+defaultImportMaps = [{
+  importPath: 'defaultItemName'
+}]
 
-  const namedImportMaps = noNulls(exportSuiteTrees
-    .map(t => t.namedDepImports))
-  const defaultImportMaps = noNulls(exportSuiteTrees
-    .map(t => t.defaultDepImports))
-
+*/
+export const buildImportStmts = (namedImportMaps, defaultImportMaps, exportSuiteTrees) => {
   const imports = {}
 
-  exportSuiteTrees.forEach(t => {
-    const sutImports = imports[t.inputModulePath] || {}
-    if (t.defaultSut) {
-      sutImports.default = t.defaultSut
-    }
-    if (t.namedSut) {
-      sutImports.named = t.defaultSut
-    }
-     if (sutImports.named || sutImports.default) {
-       imports[t.inputModulePath] = sutImports
-     }
-  })
-
+  if (exportSuiteTrees) {
+    exportSuiteTrees.forEach(t => {
+      const sutImports = imports[t.inputModulePath] || {}
+      if (t.defaultSut) {
+        sutImports.default = t.defaultSut
+      }
+      if (t.namedSut) {
+        sutImports.named = t.defaultSut
+      }
+       if (sutImports.named || sutImports.default) {
+         imports[t.inputModulePath] = sutImports
+       }
+    })
+  }
+  
   namedImportMaps.forEach(curr => {
     Object.keys(curr).forEach(k => {
       const namedList = curr[k]
@@ -108,6 +120,10 @@ export const fn = (...body) => {
   return e.function([], noNulls(body))
 }
 
+export const fnArgs = (args, ...rest) => {
+  return e.function(args, noNulls(rest))
+}
+
 export const vr = (name, val) => {
   return e.var(e.id(name), val)
 }
@@ -115,3 +131,5 @@ export const vr = (name, val) => {
 export const callFn = (callee, args) => {
   return e.call(isString(callee) ? e.identifier(callee) : callee, args || [])
 }
+
+export const raw = e.id

--- a/menus/fancy-react.json
+++ b/menus/fancy-react.json
@@ -2,8 +2,12 @@
   "context-menu": {
     "atom-text-editor": [
       {
-        "label": "Generate fancy-react",
+        "label": "Generate Component from snippet (fancy-react)",
         "command": "fancy-react:generate"
+      },
+      {
+        "label": "Generate tests for source file (fancy-react)",
+        "command": "fancy-react:tests"
       }
     ]
   },
@@ -15,8 +19,12 @@
           "label": "fancy-react",
           "submenu": [
             {
-              "label": "Generate",
+              "label": "Generate Component from snippet",
               "command": "fancy-react:generate"
+            },
+            {
+              "label": "Generate tests for source file",
+              "command": "fancy-react:tests"
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "acorn-jsx": "^4.0.1",
     "astring": "^1.0.2",
     "babylon": "^6.17.1",
-    "estree-builder": "^1.6.0",
+    "estree-builder": "git://github.com/eddiesholl/estree-builder.git#8b7365e",
     "mkdirp": "^0.5.1",
     "ramda": "^0.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "acorn-jsx": "^4.0.1",
     "astring": "^1.0.2",
     "babylon": "^6.17.1",
-    "estree-builder": "git://github.com/eddiesholl/estree-builder.git#8b7365e",
+    "estree-builder": "git://github.com/eddiesholl/estree-builder.git#c54ceee",
     "mkdirp": "^0.5.1",
     "ramda": "^0.24.0"
   },

--- a/spec/tree-builders-spec.js
+++ b/spec/tree-builders-spec.js
@@ -12,7 +12,9 @@ import {
 
 import {
   genJs,
-  genJsList,
+  genJsList
+} from '../lib/js-gen'
+import {
   propTypeToMock
 } from '../lib/test-content'
 
@@ -75,20 +77,20 @@ describe('tree-builders', () => {
 
   describe('buildImportStmts', () => {
     it('handles empty imports', () => {
-      const result = buildImportStmts([])
+      const result = buildImportStmts([], [])
       expect(genJsList(result)).toEqual('')
     })
 
     it('handles a named import', () => {
     //  const result = buildImportStmts([{ 'src/foo': ['named'] }], [])
-      const input = [{ namedDepImports: { 'src/foo': ['named'] } }]
-      const result = buildImportStmts(input)
+      const input = [{ 'src/foo': ['named'] }]
+      const result = buildImportStmts(input, [])
       expect(genJsList(result)).toEqual(`import { named } from 'src/foo'`)
     })
 
     it('handles a default import', () => {
-      const input = [{ defaultDepImports: { 'src/foo': 'Default' } }]
-      const result = buildImportStmts(input)
+      const input = [{ 'src/foo': 'Default' }]
+      const result = buildImportStmts([], input)
       const expected = `import Default from 'src/foo'`
       expect(genJsList(result)).toEqual(expected)
       cmp(genJsList(result), expected)


### PR DESCRIPTION
Allow the use case of typing out what you think a component will be called as, and generate a component implementation based on this.

For example:

```
export class ClassBased extends Component {
  render() {
    return (
      <Nested a={'a'} b={'b'}>
        <div />
      </Nested>
    )
  }
}
```

Place the cursor inside the `Nested` block, and run `generate`

```
import React, { Component } from 'react'
import PropTypes from 'prop-types'
import styles from './Nested.scss'
class Nested extends Component {
  render() {
    var {a, b} = this.props;
    return (
      <div>
        Here is a 'Nested'
      </div>
    );
  }
}
Nested.propTypes = {
  "a": PropTypes.object.isRequired,
  "b": PropTypes.object.isRequired
}
export default Nested
```

This closes https://github.com/eddiesholl/atom-fancy-react/issues/6