### PR TITLE
Make the jsx node search find more specific matches

### DIFF
--- a/lib/node-ops.js
+++ b/lib/node-ops.js
@@ -1,53 +1,57 @@
 'use babel'
 
-const singleNodesToSearch = [
+const firstVal = (a) => {
+  return a.filter(hasValue).shift()
+}
+const nodesToDescend = [
   'declaration', 'id', 'init', 'body', 'expression',
-  'left', 'right', 'value', 'argument', 'openingElement'
+  'left', 'right', 'value', 'argument', 'openingElement',
+  'declarations', 'children'
 ]
-const multiNodesToSearch = ['declarations', 'body']
 
 export const searchByType = (node, type) => {
   return searchBy(node, byType(type))
 }
 
-export const searchBy = (currentNode, tester) => {
-  const currentResult = tester(currentNode)
-  if (currentResult) {
+export const searchBy = (currentNode, tester, options = {}) => {
+  const currentTesterResult = tester(currentNode)
+  var currentResult
+  if (currentTesterResult) {
     // allow testers to return a 'lookahead' node match
-    return (typeof(currentResult) === "boolean")
+    currentResult = (currentTesterResult === true)
         ? currentNode
-        : currentResult
+        : currentTesterResult
   }
 
+  var lowerResult
   if (Array.isArray(currentNode)) {
-    return currentNode
-      .map(n => {
-        return searchBy(n, tester)
-      })
-      .find(hasValue)
+    lowerResult = firstVal(
+      currentNode
+        .map(n => {
+          return searchBy(n, tester, options)
+        }))
   } else {
-    const singleMatch = singleNodesToSearch.map(s => {
-      const nextChild = currentNode[s]
-      if (nextChild) {
-        return searchBy(nextChild, tester)
-      }
-    }).find(hasValue)
-
-    if (singleMatch) {
-      return singleMatch
-    } else {
-      const multiMatch = multiNodesToSearch.map(s => {
-        const nextChild = currentNode[s]
-        if (nextChild && nextChild.find) {
-          return nextChild.find(d => {
-            return searchBy(d, tester)
-          })
+    lowerResult = firstVal(
+      nodesToDescend.map(s => {
+        const nextDescent = currentNode[s]
+        if (nextDescent) {
+          if (nextDescent.map) {
+            return firstVal(
+              nextDescent.map(d => {
+                return searchBy(d, tester, options)
+              }))
+          } else {
+            return searchBy(nextDescent, tester, options)
+          }
         }
-      }).find(hasValue)
-
-      return multiMatch
-    }
+      }))
   }
+
+  const result = options.lower ?
+    lowerResult || currentResult :
+    currentResult || lowerResult
+
+  return result
 }
 
 export const searchByLocation = (node, point) => {
@@ -56,7 +60,7 @@ export const searchByLocation = (node, point) => {
 export const searchByLocationAndType = (node, point, type) => {
   const bl = byLocation(point)
   const bt = byType(type)
-  return searchBy(node, (n) => bt(n) && bl(n))
+  return searchBy(node, (n) => bt(n) && bl(n), { lower: true })
 }
 
 const pointAfter = (p, a) => {

--- a/spec/node-ops-spec.js
+++ b/spec/node-ops-spec.js
@@ -2,9 +2,58 @@
 
 import e from 'estree-builder'
 
-import { searchByType, searchForPropTypes } from '../lib/node-ops'
+import {
+  searchByType,
+  searchForPropTypes,
+  searchByLocationAndType
+} from '../lib/node-ops'
 
 describe('node-ops', () => {
+  describe('searchByLocationAndType', () => {
+    const insideFindMe = {
+      type: 'JSXElement',
+      name: { name: 'insideFindMe' },
+      loc: { start: { column: 5, line: 6 }, end: { column: 8, line: 6 }}}
+    const findMe = {
+      type: 'JSXElement',
+      name: { name: 'findMe' },
+      children: [insideFindMe],
+      loc: { start: { column: 5, line: 5 }, end: { column: 5, line: 7 }}}
+    const siblingOfFindMe = {
+      type: 'JSXElement',
+      name: { name: 'siblingOfFindMe' },
+      loc: { start: { column: 5, line: 8 }, end: { column: 5, line: 9 }}}
+    const parent = {
+      type: 'JSXElement',
+      name: { name: 'parent' },
+      children: [findMe, siblingOfFindMe],
+      loc: { start: { column: 5, line: 4 }, end: { column: 5, line: 10 }}}
+
+    it('can find a jsx node within a jsx tree', () => {
+      const result = searchByLocationAndType(
+        parent, { line: 5, column: 6 },
+        'JSXElement'
+      )
+      expect(result).toEqual(findMe)
+    })
+
+    it('can find a fully nested jsx node', () => {
+      const result = searchByLocationAndType(
+        parent, { line: 6, column: 6 },
+        'JSXElement'
+      )
+      expect(result).toEqual(insideFindMe)
+    })
+
+    it('can find a nested jsx node on the closing tag', () => {
+      const result = searchByLocationAndType(
+        parent, { line: 7, column: 4 },
+        'JSXElement'
+      )
+      expect(result).toEqual(findMe)
+    })
+  })
+
   describe('searchByType', () => {
     const idChild = { type: 'idChild' }
     const rootNode = {


### PR DESCRIPTION
Add an option to the tree search to pick lower results over higher. Is not guaranteed to find the lowest node, but more likely.