### PR TITLE
Add support for static propTypes definition

### DIFF
--- a/lib/acorn.js
+++ b/lib/acorn.js
@@ -1,12 +1,16 @@
 'use babel'
 
-const acorn = require('acorn-jsx');
+var acorn = require('acorn');
+var injectAcornJsx = require('acorn-jsx/inject');
+var injectAcornStaticClassPropertyInitializer = require('acorn-static-class-property-initializer/inject');
+injectAcornJsx(acorn);
+injectAcornStaticClassPropertyInitializer(acorn);
 
 const defaultAcornOptions = {
     sourceType: 'module',
     ecmaVersion: 6,
     locations: true,
-    plugins: { jsx: true }
+    plugins: { jsx: true, staticClassPropertyInitializer: true }
 }
 
 export const parse = (input) => {

--- a/lib/node-ops.js
+++ b/lib/node-ops.js
@@ -95,7 +95,7 @@ export const searchBySuperClass = (node, superClassName) => {
 }
 
 export const searchForPropTypes = (node, componentName) => {
-  const tester = (node) => {
+  const legacyTester = (node) => {
     const isAssignment = byType('AssignmentExpression')(node)
     const left = node.left
 
@@ -109,7 +109,20 @@ export const searchForPropTypes = (node, componentName) => {
       }
     }
   }
-  return searchBy(node, tester)
+  const staticPropTypesTester = (node) => {
+    return byType('ClassProperty')(node) &&
+      node.static &&
+      node.key && node.key.name === 'propTypes'
+  }
+
+  const legacyMatch = searchBy(node, legacyTester)
+  if (legacyMatch) { return legacyMatch }
+
+  const classDef = searchBySuperClass(node, 'Component')
+  const staticProps = searchBy(classDef, staticPropTypesTester)
+  if (staticProps && staticProps.value) {
+    return staticProps.value.properties
+  }
 }
 
 export const searchByIdName = (node, idName) => {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "acorn": "^4.0.13",
     "acorn-jsx": "^4.0.1",
+    "acorn-static-class-property-initializer": "^1.0.0",
     "astring": "^1.0.2",
     "babylon": "^6.17.1",
     "estree-builder": "git://github.com/eddiesholl/estree-builder.git#c54ceee",

--- a/spec/acorn-spec.js
+++ b/spec/acorn-spec.js
@@ -1,0 +1,19 @@
+'use babel'
+
+import { parse } from '../lib/acorn'
+
+const classDef = `
+class Foo extends Bar {
+  static propTypes = { a: 'b' }
+
+  render() {}
+}`
+describe('acorn', () => {
+
+  describe('parse', () => {
+      it('can process a Class', () => {
+        const result = parse(classDef)
+        //expect(result).toEqual(projectPath1)
+      })
+  })
+})

--- a/spec/node-ops-spec.js
+++ b/spec/node-ops-spec.js
@@ -99,6 +99,7 @@ describe('node-ops', () => {
         properties: propTypeProperties
       }
     }
+
     it('works', () => {
       const result = searchForPropTypes(propTypeAssignment, 'Class')
       expect(result).toEqual(propTypeProperties)

--- a/spec/test-content-spec.js
+++ b/spec/test-content-spec.js
@@ -20,6 +20,42 @@ describe("randoFunc", function () {
   })
 })`
 
+const classLegacyPropsInput = `
+export class Foo extends Component {
+  render() {}
+}
+Foo.propTypes = { a: PropTypes.string.isRequired, b: PropTypes.object }
+`
+const classStaticPropsInput = `
+export class Foo extends Component {
+  static propTypes = { a: PropTypes.string.isRequired, b: PropTypes.object }
+  render() {}
+}`
+const classOutput = `
+import { Foo } from '/a/b'
+import { shallow } from 'enzyme'
+import React from 'react'
+
+describe("render Foo", function () {
+  var aMock;
+  var bMock;
+  beforeEach(function () {
+    aMock = "aMock"
+    bMock = "bMock"
+  })
+  function renderComponent(props) {
+    props = props || {}
+    return shallow(
+      <Foo
+        a={aMock}
+        b={bMock}
+        {...props} />);
+  }
+  it("can render", function () {
+    var result = renderComponent();
+    expect(result).to.deep.equal(result)
+  })
+})`
 describe('test-content', () => {
 
   describe('generate', () => {
@@ -32,6 +68,16 @@ describe('test-content', () => {
       const result = generate(
         randoFuncInput, null, sampleModulePath)
       expect(result).toEqual(randoFuncOutput)
+    })
+
+    it('works with a component class', () => {
+      const result = generate(classLegacyPropsInput, null, sampleModulePath)
+      expect(result).toEqual(classOutput)
+    })
+
+    it('works with a component class with static properties', () => {
+      const result = generate(classStaticPropsInput, null, sampleModulePath)
+      expect(result).toEqual(classOutput)
     })
   })
 


### PR DESCRIPTION
Add parsing support for static class properties, and enhance propTypes search to be able to find them

Closes https://github.com/eddiesholl/atom-fancy-react/issues/18