### PR TITLE
Add support for config settings for package structure and paths

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,6 @@
   "rules": {
     "no-console": 0,
     "no-undef": "error",
-    "indent": ["error", 2]
+    "indent": ["error", 2, { "SwitchCase": 1 }]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
   },
   "rules": {
     "no-console": 0,
-    "no-undef": 0,
-    "indent": 0
+    "no-undef": "error",
+    "indent": ["error", 2]
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,9 +27,45 @@ Start from a snippet of a proposed React component in some jsx somewhere, and ge
 
 ![generate](https://github.com/eddiesholl/atom-fancy-react/raw/master/doc/generate-component.gif "generate")
 
-# Implementation & Dependencies
+# Package configuration
 
-The plugin makes heavy use of javascript ASTs to process input source code, and to generate output code. Currently the parsing is done using `acorn` and `acorn-jsx`, node construction via `estree-builder`, and generation by `astring`. This is more labor intensive than simple string templates but should allow much richer functionality and opportunity for extension.
+All configuration items can be set globally using the Atom settings page for `fancy-react`. If you have a React repo that needs some specific configuration, you can include keys inside that repo's `package.json` file, under a `fancyReact` key.
+
+```json
+},
+"devDependencies": {
+  "chai": "^4.0.2",
+  "react-dom": "^15.6.1",
+  "react-test-renderer": "^15.6.1"
+},
+"fancyReact": {
+  "testStructure": "SubDir",
+  "packagePath": "client",
+  "sourcePath": "src",
+  "testPath": "test",
+  "testSuffix": "-test"
+}
+```
+You can see an example config in the [package.json](https://github.com/eddiesholl/atom-fancy-react-test/blob/master/package.json#L43) file for `atom-fancy-react-test`.
+
+The examples here all describe a component defined at `<rootDir>/client/src/components/Foo/Foo.js`.
+## testStructure
+What is the general strategy for storing test files.
+
+- ParallelDirs - The entire src folder is mirrored, and contains all of your tests. For example `client/src/components/Foo/Foo.js` -> `client/test/components/Foo/Foo-test.js`
+
+- SameDir - Every test lives in the same folder as its source file. For example `client/src/components/Foo/Foo.js` -> `client/src/components/Foo/Foo-test.js`
+
+- SubDir - Every test lives in a sub folder of where the source file is. For example `client/src/components/Foo/Foo.js` -> `client/src/components/Foo/test/Foo-test.js`
+
+## packagePath
+What is the path within the repo to the start of the react code. For example, `client`
+## sourcePath
+What is the path within the react root to get to the source files. For example, `src`
+## testPath
+What is the path within the react root to get to the test files. In `ParallelDirs` mode, for the example above, `test`. This is also a valid value for `SubDir` mode, it will nest test files under their source folder at `test`.
+## testSuffix
+The suffix to append to the source file name. For example, `-test`.
 
 # Resources
 
@@ -37,7 +73,11 @@ There is a sample package available at https://github.com/eddiesholl/atom-fancy-
 
 # Contributing
 
-If your particular configuration is not supported, feel free to open an issue and describe the changes you are looking for. Pull requests are most welcome!
+The success of this package is based on supporting a wide range of dependencies, styles, approaches and package conventions. If your particular configuration is not supported, feel free to open an issue and describe the changes you are looking for. Pull requests are also most welcome!
+
+# Implementation & Dependencies
+
+The plugin makes heavy use of javascript ASTs to process input source code, and to generate output code. Currently the parsing is done using `acorn` and `acorn-jsx`, node construction via `estree-builder`, and generation by `astring`. This is more labor intensive than simple string templates but should allow much richer functionality and opportunity for extension.
 
 # Future items
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,33 @@
+'use babel'
+
+const R = require('ramda')
+
+const settingsToLoad =
+  ["testStructure", "packagePath", "sourcePath", "testPath", "testSuffix"]
+
+module.exports = () => {
+
+  const userConfig =
+    R.fromPairs(settingsToLoad.map(s => [s, atom.config.get(`fancy-react.${s}`)]))
+
+  const pathFromProject = atom.project.getPaths().shift()
+  /*const editor = atom.workspace.getActivePaneItem()
+  const pathFromEditor = editor ? pathEnv.getProjectRoot(editor.getPath()) : ''*/
+  const projectRoot = pathFromProject //|| pathFromEditor
+
+  var pkgConfig = {}
+
+  try {
+    var doc = require(`${projectRoot}/package.json`);
+    pkgConfig = R.pick(settingsToLoad, doc.fancyReact)
+  } catch (e) {
+    return userConfig
+  }
+
+  const mergedConfig = R.merge(userConfig, pkgConfig)
+
+  return {
+    ...mergedConfig,
+    projectRoot
+  }
+}

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -31,6 +31,8 @@ class FancyReact {
         }));
 
         this.config = loadConfig()
+        this.pathFuncs = pathFuncs(this.config)
+        this.pathEnv = pathEnv(this.pathFuncs)
     }
 
     deactivate() {
@@ -45,16 +47,15 @@ class FancyReact {
     }
 
     tests() {
-        const editor = atom.workspace.getActivePaneItem()
+        const activeEditor = atom.workspace.getActivePaneItem()
 
-        const inputFilePath = editor.getPath()
-        const projectRoot = pathEnv.getProjectRoot(inputFilePath)
-        const inputText = editor.getText()
-        const testFilePath = pathFuncs.sourceFileToTestFile(inputFilePath, projectRoot)
-        const inputModulePath = pathFuncs.sourceFileToModulePath(inputFilePath, projectRoot)
+        const inputFilePath = activeEditor.getPath()
+        const inputText = activeEditor.getText()
+        const testFilePath = this.pathFuncs.sourceFileToTestFile(inputFilePath)
+        const inputModulePath = this.pathFuncs.sourceFileToModulePath(inputFilePath)
 
         if (!fs.existsSync(testFilePath)) {
-          pathEnv.ensureFolderExists(testFilePath)
+          this.pathEnv.ensureFolderExists(testFilePath)
         }
 
         atom.workspace.open(testFilePath).then(editor => {
@@ -67,19 +68,15 @@ class FancyReact {
     generate() {
       const editor = atom.workspace.getActivePaneItem()
 
-      const inputFilePath = editor.getPath()
-      const projectRoot = pathEnv.getProjectRoot(inputFilePath)
       const inputText = editor.getText()
       const bufferPosition = editor.getCursorBufferPosition()
 
       const result = genReact(inputText, bufferPosition)
 
-      const componentDetails = pathFuncs.componentDetails(
-        projectRoot,
-        result.componentName)
+      const componentDetails = this.pathFuncs.componentDetails(result.componentName)
 
       if (!fs.existsSync(componentDetails.folderPath)) {
-        pathEnv.createComponentFolder(componentDetails)
+        this.pathEnv.createComponentFolder(componentDetails)
       }
 
       atom.workspace.open(componentDetails.componentPath).then(editor => {

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -2,6 +2,7 @@
 const CompositeDisposable = require('atom').CompositeDisposable;
 const fs = require('fs');
 
+const loadConfig = require('./config');
 const pathEnv = require('./path-env');
 const pathFuncs = require('./path-funcs');
 const testContent = require('./test-content');
@@ -28,6 +29,8 @@ class FancyReact {
             'fancy-react:tests': () => this.tests(),
             'fancy-react:generate': () => this.generate()
         }));
+
+        this.config = loadConfig()
     }
 
     deactivate() {

--- a/lib/path-env.js
+++ b/lib/path-env.js
@@ -2,41 +2,41 @@ const fs = require('fs')
 const path = require('path')
 const mkdirp = require('mkdirp')
 
-const p = require('./path-funcs')
-
-const getProjectRoot = (sourceFile) => {
-  const projectPaths = atom.project.getPaths()
-  return p.findProjectFor(sourceFile, projectPaths)
-}
-
-const getTestFilePath = (sourceFile) => {
-  const projectRoot = getProjectRoot(sourceFile)
-  return p.sourceFileToTestFile(sourceFile, projectRoot)
-}
-
-const ensureFolderExists = (pathToCheck) => {
-  const dirPath = path.extname(pathToCheck) ? path.dirname(pathToCheck) : pathToCheck
-  if (!fs.existsSync(dirPath)) {
-    mkdirp.sync(dirPath)
+module.exports = (pathFuncs) => {
+  const getProjectRoot = (sourceFile) => {
+    const projectPaths = atom.project.getPaths()
+    return pathFuncs.findProjectFor(sourceFile, projectPaths)
   }
-}
 
-const ensureFileExists = (pathToCheck) => {
-
-  if (!fs.existsSync(pathToCheck)) {
-    fs.closeSync(fs.openSync(pathToCheck, 'w'))
+  const getTestFilePath = (sourceFile) => {
+    const projectRoot = getProjectRoot(sourceFile)
+    return pathFuncs.sourceFileToTestFile(sourceFile, projectRoot)
   }
-}
 
-const createComponentFolder = (componentDetails) => {
-  ensureFolderExists(componentDetails.folderPath)
-  ensureFileExists(componentDetails.stylesPath)
-  ensureFileExists(componentDetails.componentPath)
-}
+  const ensureFolderExists = (pathToCheck) => {
+    const dirPath = path.extname(pathToCheck) ? path.dirname(pathToCheck) : pathToCheck
+    if (!fs.existsSync(dirPath)) {
+      mkdirp.sync(dirPath)
+    }
+  }
 
-module.exports = {
-  getTestFilePath,
-  ensureFolderExists,
-  getProjectRoot,
-  createComponentFolder
+  const ensureFileExists = (pathToCheck) => {
+
+    if (!fs.existsSync(pathToCheck)) {
+      fs.closeSync(fs.openSync(pathToCheck, 'w'))
+    }
+  }
+
+  const createComponentFolder = (componentDetails) => {
+    ensureFolderExists(componentDetails.folderPath)
+    ensureFileExists(componentDetails.stylesPath)
+    ensureFileExists(componentDetails.componentPath)
+  }
+
+  return {
+    getTestFilePath,
+    ensureFolderExists,
+    getProjectRoot,
+    createComponentFolder
+  }
 }

--- a/lib/path-funcs.js
+++ b/lib/path-funcs.js
@@ -16,6 +16,26 @@ module.exports = (config) => {
   const srcInsideProject = path.join('/' + config.packagePath, config.sourcePath)
   const testInsideProject = path.join('/' + config.packagePath, config.testPath)
 
+  const flipSrcPathToTestPath = (sourceFileWithinProject) => {
+    const sourceFileMinusExt = removeExtension(sourcePathWithinSrc(sourceFileWithinProject))
+
+    const pathPieces = [testInsideProject, sourceFileMinusExt, config.testSuffix, '.js']
+    return path.normalize(pathPieces.join(''))
+  }
+
+  const srcPathToTestPathSameDir = (sourceFileWithinProject) => {
+    return removeExtension(sourceFileWithinProject) + config.testSuffix + '.js'
+  }
+
+  const srcPathToTestPathSubDir = (sourceFileWithinProject) => {
+    const srcDir = path.dirname(sourceFileWithinProject)
+    const fileName = path.basename(sourceFileWithinProject)
+    return path.join(
+      srcDir,
+      config.testPath,
+      removeExtension(fileName) + config.testSuffix + '.js')
+  }
+
   const sourceFileToTestFile = (sourceFile) => {
     const sourceFileWithinProject = fullPathToProjectPath(sourceFile)
 
@@ -23,10 +43,25 @@ module.exports = (config) => {
       throw new Error(`Source file ${sourceFileWithinProject} not inside src folder ${srcInsideProject}`)
     }
 
-    const sourceFileMinusExt = removeExtension(sourcePathWithinSrc(sourceFileWithinProject))
+    var testFile
+    switch (config.testStructure) {
+      case 'ParallelDirs':
+        testFile = flipSrcPathToTestPath(sourceFileWithinProject)
+        break;
 
-    const pathPieces = [config.projectRoot, testInsideProject, sourceFileMinusExt, config.testSuffix, '.js']
-    return path.normalize(pathPieces.join(''))
+      case 'SameDir':
+        testFile = srcPathToTestPathSameDir(sourceFileWithinProject)
+        break;
+
+      case 'SubDir':
+        testFile = srcPathToTestPathSubDir(sourceFileWithinProject)
+        break;
+
+      default:
+        throw `${config.testStructure} is not supported test structure`
+    }
+
+    return path.join(config.projectRoot, testFile)
   }
 
   const removeExtension = (path) =>  path.replace(/\..+$/, '')

--- a/lib/path-funcs.js
+++ b/lib/path-funcs.js
@@ -1,9 +1,5 @@
 const path = require('path');
 
-const srcInsideProject = '/client/src'
-const testInsideProject = '/client/test'
-const testFileSuffix = '-test.js'
-
 const findProjectFor = (sourceFile, projectPaths) => {
   const sourceFileNormal = path.normalize(sourceFile)
   return projectPaths
@@ -15,60 +11,66 @@ const findProjectFor = (sourceFile, projectPaths) => {
     })
 }
 
-const sourceFileToTestFile = (sourceFile, projectRoot) => {
-  const sourceFileWithinProject = fullPathToProjectPath(sourceFile, projectRoot)
+module.exports = (config) => {
 
-  if (!sourceFileWithinProject.startsWith(srcInsideProject)) {
-    throw new Error(`Source file ${sourceFileWithinProject} not inside src folder ${srcInsideProject}`)
+  const srcInsideProject = path.join('/' + config.packagePath, config.sourcePath)
+  const testInsideProject = path.join('/' + config.packagePath, config.testPath)
+
+  const sourceFileToTestFile = (sourceFile) => {
+    const sourceFileWithinProject = fullPathToProjectPath(sourceFile)
+
+    if (!sourceFileWithinProject.startsWith(srcInsideProject)) {
+      throw new Error(`Source file ${sourceFileWithinProject} not inside src folder ${srcInsideProject}`)
+    }
+
+    const sourceFileMinusExt = removeExtension(sourcePathWithinSrc(sourceFileWithinProject))
+
+    const pathPieces = [config.projectRoot, testInsideProject, sourceFileMinusExt, config.testSuffix, '.js']
+    return path.normalize(pathPieces.join(''))
   }
 
-  const sourceFileMinusExt = removeExtension(sourcePathWithinSrc(sourceFileWithinProject))
+  const removeExtension = (path) =>  path.replace(/\..+$/, '')
 
-  const pathPieces = [projectRoot, testInsideProject, sourceFileMinusExt, testFileSuffix]
-  return path.normalize(pathPieces.join(''))
-}
+  const fullPathToProjectPath = (sourceFile) => {
+    if (!sourceFile.startsWith(config.projectRoot)) {
+      throw new Error(`Source file ${sourceFile} not part of project ${config.projectRoot}`)
+    }
 
-const removeExtension = (path) =>  path.replace(/\..+$/, '')
-
-const fullPathToProjectPath = (sourceFile, projectRoot) => {
-  if (!sourceFile.startsWith(projectRoot)) {
-    throw new Error(`Source file ${sourceFile} not part of project ${projectRoot}`)
+    return sourceFile.slice(config.projectRoot.length)
   }
 
-  return sourceFile.slice(projectRoot.length)
-}
+  const sourceFileToModulePath = (sourceFile) => {
+    const sourceFileWithinProject = fullPathToProjectPath(sourceFile)
+    return 'src' + removeExtension(sourcePathWithinSrc(sourceFileWithinProject))
+  }
 
-const sourceFileToModulePath = (sourceFile, projectRoot) => {
-  const sourceFileWithinProject = fullPathToProjectPath(sourceFile, projectRoot)
-  return 'src' + removeExtension(sourcePathWithinSrc(sourceFileWithinProject))
-}
-
-const sourcePathWithinSrc = (sourceFileWithinProject) => {
+  const sourcePathWithinSrc = (sourceFileWithinProject) => {
     return sourceFileWithinProject.slice(srcInsideProject.length)
-}
+  }
 
-const moduleName = path.basename
+  const moduleName = path.basename
 
-const componentDetails = (projectRoot, componentName) => {
-  const folderPath = `${projectRoot}/client/src/components/${componentName}`
-  const componentPath = `${folderPath}/${componentName}.js`
-  const stylesPath = `${folderPath}/${componentName}.scss`
+  const componentDetails = (componentName) => {
+    const folderPath = `${config.projectRoot}/client/src/components/${componentName}`
+    const componentPath = `${folderPath}/${componentName}.js`
+    const stylesPath = `${folderPath}/${componentName}.scss`
+
+    return {
+      projectRoot: config.projectRoot,
+      componentName,
+      folderPath,
+      componentPath,
+      stylesPath
+    }
+  }
 
   return {
-    projectRoot,
-    componentName,
-    folderPath,
-    componentPath,
-    stylesPath
+    findProjectFor,
+    sourceFileToTestFile,
+    fullPathToProjectPath,
+    sourceFileToModulePath,
+    sourcePathWithinSrc,
+    moduleName,
+    componentDetails
   }
-}
-
-module.exports = {
-  findProjectFor,
-  sourceFileToTestFile,
-  fullPathToProjectPath,
-  sourceFileToModulePath,
-  sourcePathWithinSrc,
-  moduleName,
-  componentDetails
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "testPath": {
       "type": "string",
       "order": 3,
-      "title": "Test root within package",
-      "description": "Only needed when using ParallelDirs",
+      "title": "Name of directory that contains tests",
+      "description": "ParallelDirs -> dir name inside react root. SubDir -> Name of the sub directory",
       "default": "test"
     },
     "testSuffix": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,47 @@
     "react",
     "code generation"
   ],
+  "configSchema": {
+    "testStructure": {
+      "type": "string",
+      "order": 0,
+      "title": "Test structure",
+      "default": "ParallelDirs",
+      "description": "How do you prefer to store tests?",
+      "enum": [
+        "ParallelDirs",
+        "SameDir",
+        "SubDir"
+      ]
+    },
+    "packagePath": {
+      "type": "string",
+      "order": 1,
+      "title": "React root within package",
+      "description": "Relative path from the actual package root",
+      "default": "client"
+    },
+    "sourcePath": {
+      "type": "string",
+      "order": 2,
+      "title": "Path from react root to source code",
+      "default": "src"
+    },
+    "testPath": {
+      "type": "string",
+      "order": 3,
+      "title": "Test root within package",
+      "description": "Only needed when using ParallelDirs",
+      "default": "test"
+    },
+    "testSuffix": {
+      "type": "string",
+      "order": 4,
+      "title": "The filename suffix added to your test files",
+      "description": "For example Foo.js -> Foo-test.js",
+      "default": "-test"
+    }
+  },
   "scripts": {
     "test": "babel-node spec/run.js",
     "test:watch": "nodemon ./node_modules/babel-cli/bin/babel-node.js spec/run.js",

--- a/spec/path-funcs-spec.js
+++ b/spec/path-funcs-spec.js
@@ -1,21 +1,29 @@
 'use babel'
 
 import paths from '../lib/path-funcs'
+const pathsParallelDirs = paths({
+  testStructure: 'ParallelDirs',
+  packagePath: 'client',
+  sourcePath: 'src',
+  testPath: 'test',
+  testSuffix: '-test',
+  projectRoot: '/a/b'
+})
 
 const projectPath1 = '/a/b'
 
-describe('paths', () => {
+describe('paths with ParallelDirs', () => {
 
   describe('findProjectFor', () => {
       it('finds a simple case', () => {
-        const result = paths.findProjectFor('/a/b/foo.txt', [projectPath1])
+        const result = pathsParallelDirs.findProjectFor('/a/b/foo.txt', [projectPath1])
         expect(result).toEqual(projectPath1)
       })
   }),
 
   describe('sourceFileToTestFile', () => {
     it('can translate a simple source file', () => {
-      const result = paths.sourceFileToTestFile(
+      const result = pathsParallelDirs.sourceFileToTestFile(
         projectPath1 + '/client/src/foo/bar.js',
         projectPath1)
       expect(result).toEqual(projectPath1 + '/client/test/foo/bar-test.js')

--- a/spec/path-funcs-spec.js
+++ b/spec/path-funcs-spec.js
@@ -1,32 +1,61 @@
 'use babel'
 
-import paths from '../lib/path-funcs'
-const pathsParallelDirs = paths({
-  testStructure: 'ParallelDirs',
+import pathFuncs from '../lib/path-funcs'
+
+const configBase = {
   packagePath: 'client',
   sourcePath: 'src',
   testPath: 'test',
   testSuffix: '-test',
   projectRoot: '/a/b'
-})
+}
+const configParallelDirs = { testStructure: 'ParallelDirs', ...configBase }
+const configSameDir = { testStructure: 'SameDir', ...configBase }
+const configSubDir = { testStructure: 'SubDir', ...configBase }
+
+const pfParallelDirs = pathFuncs(configParallelDirs)
+const pfSameDir = pathFuncs(configSameDir)
+const pfSubDir = pathFuncs(configSubDir)
 
 const projectPath1 = '/a/b'
 
-describe('paths with ParallelDirs', () => {
+describe('path-funcs with ParallelDirs', () => {
 
   describe('findProjectFor', () => {
       it('finds a simple case', () => {
-        const result = pathsParallelDirs.findProjectFor('/a/b/foo.txt', [projectPath1])
+        const result = pfParallelDirs.findProjectFor('/a/b/foo.txt', [projectPath1])
         expect(result).toEqual(projectPath1)
       })
   }),
 
   describe('sourceFileToTestFile', () => {
     it('can translate a simple source file', () => {
-      const result = pathsParallelDirs.sourceFileToTestFile(
+      const result = pfParallelDirs.sourceFileToTestFile(
         projectPath1 + '/client/src/foo/bar.js',
         projectPath1)
       expect(result).toEqual(projectPath1 + '/client/test/foo/bar-test.js')
+    })
+  })
+})
+
+describe('paths with SameDir', () => {
+  describe('sourceFileToTestFile', () => {
+    it('can translate a simple source file', () => {
+      const result = pfSameDir.sourceFileToTestFile(
+        projectPath1 + '/client/src/foo/bar.js',
+        projectPath1)
+      expect(result).toEqual(projectPath1 + '/client/src/foo/bar-test.js')
+    })
+  })
+})
+
+describe('paths with SubDir', () => {
+  describe('sourceFileToTestFile', () => {
+    it('can translate a simple source file', () => {
+      const result = pfSubDir.sourceFileToTestFile(
+        projectPath1 + '/client/src/foo/bar.js',
+        projectPath1)
+      expect(result).toEqual(projectPath1 + '/client/src/foo/test/bar-test.js')
     })
   })
 })


### PR DESCRIPTION
These changes bring in some package config items that let the user control where tests get stored. The settings can be controlled in a repo's package.json file as well.

There is some fairly crude functional composition through the path lib files, that will need some refactoring at some point.