### PR TITLE
Add support for inserting new import stmt after generation

### DIFF
--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -72,10 +72,10 @@ class FancyReact {
 
   generate() {
     try {
-      const editor = atom.workspace.getActivePaneItem()
+      const activeEditor = atom.workspace.getActivePaneItem()
 
-      const inputText = editor.getText()
-      const bufferPosition = editor.getCursorBufferPosition()
+      const inputText = activeEditor.getText()
+      const bufferPosition = activeEditor.getCursorBufferPosition()
 
       const result = genReact(inputText, bufferPosition)
 
@@ -85,6 +85,15 @@ class FancyReact {
         this.pathEnv.createComponentFolder(componentDetails)
       }
 
+      if (result.inputChanges) {
+        result.inputChanges.forEach((change, ix) => {
+          activeEditor.setCursorScreenPosition(
+            { row: change.lineNumber + ix - 1, column: 0 })
+          activeEditor.insertNewline()
+          activeEditor.moveUp(1)
+          activeEditor.insertText(change.content)
+        })
+      }
       atom.workspace.open(componentDetails.componentPath).then(editor => {
         editor.setText(result.content)
       })

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -30,10 +30,12 @@ export const generate = (inputText, point) => {
 
   const importStmts = generateImports(componentName)
   const declarationStmts = generateComponents(jsxOpening)
+  const inputChanges = importNewComponent(tree.body, componentName)
 
   return {
     content: genJsList(importStmts.concat(declarationStmts)),
-    componentName
+    componentName,
+    inputChanges
   }
 }
 
@@ -61,6 +63,31 @@ export const generateComponents = (jsxNode) => {
 
   const defExport = raw(`export default ${className}`)
   return [classDecl, defProps, defExport]
+}
+
+export const importNewComponent = (nodes, compName) => {
+  const newImportPath = `src/components/${compName}/${compName}`
+  const newImportStmt = `import ${compName} from '${newImportPath}'`
+
+  const importNodes = nodes.filter(n => {
+    return n.type === 'ImportDeclaration'
+  })
+  const lastImport = importNodes.slice(-1)[0]
+
+  if (lastImport) {
+    const alreadyImported = importNodes.find(n => {
+      return n.source.value === newImportPath
+    })
+
+    if (alreadyImported) {
+      return []
+    } else {
+      return [{ lineNumber: lastImport.loc.end.line + 1, content: newImportStmt }]
+    }
+  } else {
+    return [{ lineNumber: 0, content: newImportStmt }]
+  }
+
 }
 
 const generateRender = (className, attributeNodes) => {

--- a/spec/react-content-spec.js
+++ b/spec/react-content-spec.js
@@ -1,0 +1,38 @@
+'use babel'
+
+import { importNewComponent } from '../lib/react-content'
+
+describe('react-content', () => {
+
+  describe('importNewComponent', () => {
+    const importNode1 = {
+      type: 'ImportDeclaration',
+      loc: { end: { line: 2 }},
+      source: { value: 'src/components/Foo/Foo' }
+    }
+    const importNode2 = {
+      type: 'ImportDeclaration',
+      loc: { end: { line: 6 }},
+      source: { value: 'src/components/Bar/Bar' }
+    }
+
+    it('does nothing if exists', () => {
+      const result = importNewComponent([importNode1], 'Foo')
+      expect(result).toEqual([])
+    })
+
+    it('adds an import to no imports', () => {
+      const result = importNewComponent([], 'Foo')
+      expect(result).toEqual([{
+        lineNumber: 0,
+        content: "import Foo from 'src/components/Foo/Foo'"}])
+    })
+
+    it('adds an import if missing', () => {
+      const result = importNewComponent([importNode2], 'Foo')
+      expect(result).toEqual([{
+        lineNumber: 7,
+        content: "import Foo from 'src/components/Foo/Foo'"}])
+    })
+  })
+})


### PR DESCRIPTION
Makes component generation a bit cleaner because it drops a new import statement to reference the new component after generation

Closes https://github.com/eddiesholl/atom-fancy-react/issues/34