### PR TITLE
Making config build more robust, handles no package settings

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,7 @@ const R = require('ramda')
 const settingsToLoad =
   ["testStructure", "packagePath", "sourcePath", "testPath", "testSuffix"]
 
-module.exports = () => {
+const loadConfig = () => {
 
   const userConfig =
     R.fromPairs(settingsToLoad.map(s => [s, atom.config.get(`fancy-react.${s}`)]))
@@ -15,19 +15,28 @@ module.exports = () => {
   const pathFromEditor = editor ? pathEnv.getProjectRoot(editor.getPath()) : ''*/
   const projectRoot = pathFromProject //|| pathFromEditor
 
-  var pkgConfig = {}
+  let pkgJson = {}
 
   try {
-    var doc = require(`${projectRoot}/package.json`);
-    pkgConfig = R.pick(settingsToLoad, doc.fancyReact)
+    pkgJson = require(`${projectRoot}/package.json`);
   } catch (e) {
-    return userConfig
+    atom.log(`Could not load package.json from project folder '${projectRoot}'`)
+    pkgJson = {}
   }
 
-  const mergedConfig = R.merge(userConfig, pkgConfig)
+  return buildConfig(userConfig, projectRoot, pkgJson.fancyReact)
+}
+
+const buildConfig = (userConfig, projectRoot, packageConfig = {}) => {
+  const packageConfigItems = R.pick(settingsToLoad, packageConfig)
+  const mergedConfig = R.merge(userConfig, packageConfigItems)
 
   return {
     ...mergedConfig,
     projectRoot
   }
+}
+module.exports = {
+  loadConfig,
+  buildConfig
 }

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -2,7 +2,7 @@
 const CompositeDisposable = require('atom').CompositeDisposable;
 const fs = require('fs');
 
-const loadConfig = require('./config');
+const { loadConfig } = require('./config');
 const pathEnv = require('./path-env');
 const pathFuncs = require('./path-funcs');
 const testContent = require('./test-content');

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "eslint": "^4.1.1",
     "eslint-plugin-jasmine": "^2.2.0",
-    "jasmine": "^2.6.0"
+    "jasmine": "^2.6.0",
+    "nodemon": "^1.11.0"
   }
 }

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -1,0 +1,23 @@
+'use babel'
+
+import { buildConfig } from '../lib/config'
+
+describe('config', () => {
+
+  describe('buildConfig', () => {
+    const testUserConfig = { testStructure: 'b' }
+    const testPackageConfig = { testStructure: 'c' }
+    const testProjectRoot = '/a/b'
+
+    it('can merge basic config', () => {
+      const result = buildConfig(testUserConfig, testProjectRoot)
+      expect(result.testStructure).toEqual('b')
+      expect(result.projectRoot).toEqual(testProjectRoot)
+    })
+
+    it('can merge package config', () => {
+      const result = buildConfig(testUserConfig, testProjectRoot, testPackageConfig)
+      expect(result.testStructure).toEqual('c')
+    })
+  })
+})


### PR DESCRIPTION
Improves the code used to build config, so it is more robust. In particular, handle projects that don't have any custom settings in them.

Fixes https://github.com/eddiesholl/atom-fancy-react/issues/41