### PR TITLE
Fix up generated js syntax with eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,8 +19,8 @@
   "rules": {
     "no-console": 0,
     "no-undef": "error",
-    "no-var": "error",
+    "no-var": 1,
     "indent": ["error", 2, { "SwitchCase": 1 }],
-    "semi": [2, "never"]
+    "semi": [1, "never"]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,8 @@
   "rules": {
     "no-console": 0,
     "no-undef": "error",
-    "indent": ["error", 2, { "SwitchCase": 1 }]
+    "no-var": "error",
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "semi": [2, "never"]
   }
 }

--- a/lib/acorn.js
+++ b/lib/acorn.js
@@ -14,5 +14,19 @@ const defaultAcornOptions = {
 }
 
 export const parse = (input) => {
-  return acorn.parse(input, defaultAcornOptions)
+  let comments = [], tokens = []
+  const result = acorn.parse(
+    input,
+    {
+      ...defaultAcornOptions,
+      ranges: true,
+      onComment: comments,
+      onToken: tokens
+    })
+
+  return {
+    ...result,
+    tokens,
+    comments
+  }
 }

--- a/lib/acorn.js
+++ b/lib/acorn.js
@@ -3,14 +3,16 @@
 var acorn = require('acorn');
 var injectAcornJsx = require('acorn-jsx/inject');
 var injectAcornStaticClassPropertyInitializer = require('acorn-static-class-property-initializer/inject');
+var injectAcornObjectSpreadJsx = require('acorn-object-spread/inject');
 injectAcornJsx(acorn);
 injectAcornStaticClassPropertyInitializer(acorn);
+injectAcornObjectSpreadJsx(acorn)
 
 const defaultAcornOptions = {
   sourceType: 'module',
   ecmaVersion: 6,
   locations: true,
-  plugins: { jsx: true, staticClassPropertyInitializer: true }
+  plugins: { jsx: true, staticClassPropertyInitializer: true, objectSpread: true }
 }
 
 export const parse = (input) => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,22 +18,23 @@ const loadConfig = () => {
   let pkgJson = {}
 
   try {
-    pkgJson = require(`${projectRoot}/package.json`);
+    pkgJson = require(`${projectRoot}/package.json`)
   } catch (e) {
     atom.log(`Could not load package.json from project folder '${projectRoot}'`)
     pkgJson = {}
   }
 
-  return buildConfig(userConfig, projectRoot, pkgJson.fancyReact)
+  return buildConfig(userConfig, projectRoot, pkgJson)
 }
 
-const buildConfig = (userConfig, projectRoot, packageConfig = {}) => {
-  const packageConfigItems = R.pick(settingsToLoad, packageConfig)
+const buildConfig = (userConfig, projectRoot, pkgJson = {}) => {
+  const packageConfigItems = R.pick(settingsToLoad, pkgJson.fancyReact || {})
   const mergedConfig = R.merge(userConfig, packageConfigItems)
 
   return {
     ...mergedConfig,
-    projectRoot
+    projectRoot,
+    pkgJson
   }
 }
 module.exports = {

--- a/lib/eslinter.js
+++ b/lib/eslinter.js
@@ -1,5 +1,3 @@
-const { parse } = require('./acorn')
-
 const { allowUnsafeNewFunction } = require("loophole")
 
 let eslint
@@ -8,8 +6,7 @@ allowUnsafeNewFunction(function() {
 })
 
 let CLIEngine = eslint.CLIEngine,
-  Linter = eslint.Linter,
-  SourceCode = eslint.SourceCode
+  Linter = eslint.Linter
 
 class Eslinter {
   constructor(cwd) {
@@ -18,17 +15,15 @@ class Eslinter {
   }
 
   format(text, filePath) {
-    const ast = parse(text)
     const e = this.engine
     let config
     allowUnsafeNewFunction(function() {
       config = e.getConfigForFile(filePath)
     })
-    const code = new SourceCode(text, ast)
     const linterResult = this.linter.verifyAndFix(
-      code,
-      config,
-      { filename: filePath })
+      text,
+      config
+    )
 
     return linterResult.output
   }

--- a/lib/eslinter.js
+++ b/lib/eslinter.js
@@ -1,0 +1,37 @@
+const { parse } = require('./acorn')
+
+const { allowUnsafeNewFunction } = require("loophole")
+
+let eslint
+allowUnsafeNewFunction(function() {
+  eslint = require("eslint")
+})
+
+let CLIEngine = eslint.CLIEngine,
+  Linter = eslint.Linter,
+  SourceCode = eslint.SourceCode
+
+class Eslinter {
+  constructor(cwd) {
+    this.engine = new CLIEngine({ cwd })
+    this.linter = new Linter()
+  }
+
+  format(text, filePath) {
+    const ast = parse(text)
+    const e = this.engine
+    let config
+    allowUnsafeNewFunction(function() {
+      config = e.getConfigForFile(filePath)
+    })
+    const code = new SourceCode(text, ast)
+    const linterResult = this.linter.verifyAndFix(
+      code,
+      config,
+      { filename: filePath })
+
+    return linterResult.output
+  }
+}
+
+module.exports = Eslinter

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -34,8 +34,7 @@ class FancyReact {
     this.pathFuncs = pathFuncs(this.config)
     this.pathEnv = pathEnv(this.pathFuncs)
 
-    process.env.NODE_PATH = this.config.projectRoot + '/node_modules'
-    require('module').Module._initPaths()
+    initModulePaths(this.config.projectRoot)
     const Output = require('./output');
     this.output = new Output(this.config.pkgJson, this.config.projectRoot)
   }
@@ -68,8 +67,7 @@ class FancyReact {
         const existingText = editor.getText()
         const generatedTests = testContent.generate(inputText, existingText, inputModulePath)
 
-        process.env.NODE_PATH = this.config.projectRoot + '/node_modules'
-        require('module').Module._initPaths()
+        initModulePaths(this.config.projectRoot)
 
         const formattedContent = this.output.format(
           generatedTests.content,
@@ -78,7 +76,7 @@ class FancyReact {
       })
     }
     catch (e) {
-      atom.notifications.addWarnininitModulePathsg(e.message)
+      atom.notifications.addWarning(e.message)
     }
   }
 

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -33,6 +33,11 @@ class FancyReact {
     this.config = loadConfig()
     this.pathFuncs = pathFuncs(this.config)
     this.pathEnv = pathEnv(this.pathFuncs)
+
+    process.env.NODE_PATH = this.config.projectRoot + '/node_modules'
+    require('module').Module._initPaths()
+    const Output = require('./output');
+    this.output = new Output(this.config.pkgJson, this.config.projectRoot)
   }
 
   deactivate() {
@@ -61,12 +66,19 @@ class FancyReact {
 
       atom.workspace.open(testFilePath).then(editor => {
         const existingText = editor.getText()
-        const testFileContent = testContent.generate(inputText, existingText, inputModulePath)
-        editor.setText(testFileContent)
+        const generatedTests = testContent.generate(inputText, existingText, inputModulePath)
+
+        process.env.NODE_PATH = this.config.projectRoot + '/node_modules'
+        require('module').Module._initPaths()
+
+        const formattedContent = this.output.format(
+          generatedTests.content,
+          testFilePath)
+        editor.setText(formattedContent)
       })
     }
     catch (e) {
-      atom.notifications.addWarning(e.message)
+      atom.notifications.addWarnininitModulePathsg(e.message)
     }
   }
 
@@ -95,7 +107,11 @@ class FancyReact {
         })
       }
       atom.workspace.open(componentDetails.componentPath).then(editor => {
-        editor.setText(result.content)
+        const formattedContent = this.output.format(
+          result.content,
+          componentDetails.componentPath
+        )
+        editor.setText(formattedContent)
       })
     }
     catch (e) {
@@ -105,3 +121,8 @@ class FancyReact {
 }
 
 module.exports = new FancyReact();
+
+const initModulePaths = (root) => {
+  process.env.NODE_PATH = root + '/node_modules'
+  require('module').Module._initPaths()
+}

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,0 +1,19 @@
+const Eslinter = require('./eslinter')
+
+class Output {
+  constructor(pkgJson, projectRoot) {
+    if (pkgJson && (
+      (pkgJson.dependencies && pkgJson.dependencies['eslint']) ||
+      (pkgJson.devDependencies && pkgJson.devDependencies['eslint']))) {
+      this.linter = new Eslinter(projectRoot)
+    }
+  }
+
+  format(text, fileName) {
+    return this.linter ?
+      this.linter.format(text, fileName) :
+      text
+  }
+}
+
+module.exports = Output

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -32,8 +32,10 @@ export const generate = (inputText, point) => {
   const declarationStmts = generateComponents(jsxOpening)
   const inputChanges = importNewComponent(tree.body, componentName)
 
+  const ast = importStmts.concat(declarationStmts)
   return {
-    content: genJsList(importStmts.concat(declarationStmts)),
+    content: genJsList(ast),
+    ast,
     componentName,
     inputChanges
   }

--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -66,10 +66,16 @@ export const generate = (inputText, existingText, inputModulePath) => {
   const namedExportSuites =
     mergedSuites.map(genJs).join('\n')
 
-  return `
+  const content = `
 ${genJsList(importStmts)}
 
 ${namedExportSuites}`
+  const ast = importStmts.concat(namedExportSuites)
+
+  return {
+    content,
+    ast
+  }
 }
 
 const buildSuitesFor = (exportingNodes, allNodes, inputModulePath) => {

--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -28,7 +28,7 @@ const { genJs, genJsList } = require('./js-gen')
 
 export const generate = (inputText, existingText, inputModulePath) => {
 
-  if (!inputText) { return '' }
+  if (!inputText) { return { content: '' } }
 
   const inputAST = parse(inputText)
   const inputNodes = inputAST.body

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     "acorn-static-class-property-initializer": "^1.0.0",
     "astring": "^1.0.2",
     "babylon": "^6.17.1",
+    "binary-parser": "git://github.com/shamansir/binary-parser.git#with-loophole",
+    "eslint": "^4.1.1",
+    "eslint-plugin-jasmine": "^2.6.2",
     "estree-builder": "git://github.com/eddiesholl/estree-builder.git#c54ceee",
     "mkdirp": "^0.5.1",
     "ramda": "^0.24.0"
@@ -77,7 +80,6 @@
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "eslint": "^4.1.1",
     "eslint-plugin-jasmine": "^2.2.0",
     "jasmine": "^2.6.0",
     "nodemon": "^1.11.0"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "acorn": "^4.0.13",
     "acorn-jsx": "^4.0.1",
+    "acorn-object-spread": "git://github.com/jbboehr/acorn-object-spread.git#f39f310",
     "acorn-static-class-property-initializer": "^1.0.0",
     "astring": "^1.0.2",
     "babylon": "^6.17.1",

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -6,7 +6,7 @@ describe('config', () => {
 
   describe('buildConfig', () => {
     const testUserConfig = { testStructure: 'b' }
-    const testPackageConfig = { testStructure: 'c' }
+    const testPackageConfig = { fancyReact: { testStructure: 'c' } }
     const testProjectRoot = '/a/b'
 
     it('can merge basic config', () => {

--- a/spec/test-content-spec.js
+++ b/spec/test-content-spec.js
@@ -62,23 +62,23 @@ describe('test-content', () => {
   describe('generate', () => {
     it('is empty for invalid cases', () => {
       const result = generate('', null, sampleModulePath)
-      expect(result).toEqual('')
+      expect(result.content).toEqual('')
     })
 
     it('handles a single func', () => {
       const result = generate(
         randoFuncInput, null, sampleModulePath)
-      expect(result).toEqual(randoFuncOutput)
+      expect(result.content).toEqual(randoFuncOutput)
     })
 
     it('works with a component class', () => {
       const result = generate(classLegacyPropsInput, null, sampleModulePath)
-      expect(result).toEqual(classOutput)
+      expect(result.content).toEqual(classOutput)
     })
 
     it('works with a component class with static properties', () => {
       const result = generate(classStaticPropsInput, null, sampleModulePath)
-      expect(result).toEqual(classOutput)
+      expect(result.content).toEqual(classOutput)
     })
   })
 


### PR DESCRIPTION
Use an instance of eslint to make generated syntax conform to the package local eslint config. This only applies if eslint is a dependency in the target project.