### PR TITLE
Convert var in generated output to let and const

### DIFF
--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -100,7 +100,7 @@ const generateRender = (className, attributeNodes) => {
   const thisDotProps = dot(e.this(), 'props')
   return fnArgs(
     [],
-    e.var(objPattern, thisDotProps),
+    e.const(objPattern, thisDotProps),
     e.return(e.id(`(
       <div>
         Here is a '${className}'

--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -9,7 +9,7 @@ import {
   callFn,
   dot,
   fn,
-  vr,
+  lt,
   buildBeforeEach,
   buildRenderFunc,
   buildItBlock,
@@ -131,7 +131,7 @@ const addSut = (builderResult, { isDefaultExport, exportName, inputModulePath })
 const buildSuiteForClassBased = (classComponentNode, builderOptions, allNodes) => {
   allNodes.map(n => printNode(n))
   const className = varDecName(classComponentNode)
-  const generateResult = e.var(
+  const generateResult = e.const(
     'result',
     callFn('renderComponent', []))
   const expectResult = callFn('expect', [e.id('result')])
@@ -167,7 +167,7 @@ const buildSuiteForClassBased = (classComponentNode, builderOptions, allNodes) =
 }
 
 const buildSuiteForJsx = (exportNode, { exportName }) => {
-  const generateResult = e.var('result', callFn('renderComponent', [e.id(exportName)]))
+  const generateResult = e.const('result', callFn('renderComponent', [e.id(exportName)]))
   const expectResult = callFn('expect', [e.id('result')])
   const checkResult = callFn(
     dot(dot(expectResult, 'to'), 'deepEqual'), [e.id('result')])
@@ -192,7 +192,7 @@ const buildSuiteForMapStateToProps = (exportNode, { exportName }) => {
     e.identifier('describe'),
     [
       e.string(exportName),
-      e.function([], [e.var('result', callFn(exportName, [e.identifier('state')]))])
+      e.function([], [e.const('result', callFn(exportName, [e.identifier('state')]))])
     ])
 
   return {
@@ -202,7 +202,7 @@ const buildSuiteForMapStateToProps = (exportNode, { exportName }) => {
 }
 
 const buildSuiteForBasicFunc = (exportNode, { exportName }) => {
-  const generateResult = e.var('result', callFn(exportName, []))
+  const generateResult = e.const('result', callFn(exportName, []))
   const expectResult = callFn('expect', [e.id('result')])
   const checkResult = callFn(
     dot(dot(expectResult,'to'), 'deepEqual'), [e('object-raw', [])])
@@ -254,7 +254,7 @@ export const processPropTypes = (propDefs) => {
       return {
         propName,
         mockName,
-        mockVar: vr(mockName),
+        mockVar: lt(mockName),
         mockVal
       }
     })

--- a/lib/tree-builders.js
+++ b/lib/tree-builders.js
@@ -132,6 +132,14 @@ export const vr = (name, val) => {
   return e.var(e.id(name), val)
 }
 
+export const cnst = (name, val) => {
+  return e.cnst(e.id(name), val)
+}
+
+export const lt = (name, val) => {
+  return e.let(e.id(name), val)
+}
+
 export const callFn = (callee, args) => {
   return e.call(isString(callee) ? e.identifier(callee) : callee, args || [])
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "binary-parser": "git://github.com/shamansir/binary-parser.git#with-loophole",
     "eslint": "^4.1.1",
     "eslint-plugin-jasmine": "^2.6.2",
-    "estree-builder": "git://github.com/eddiesholl/estree-builder.git#c54ceee",
+    "estree-builder": "^1.10.0",
     "mkdirp": "^0.5.1",
     "ramda": "^0.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "acorn-jsx": "^4.0.1",
     "acorn-object-spread": "git://github.com/jbboehr/acorn-object-spread.git#f39f310",
     "acorn-static-class-property-initializer": "^1.0.0",
-    "astring": "^1.0.2",
+    "astring": "^1.0.5",
     "babylon": "^6.17.1",
     "binary-parser": "git://github.com/shamansir/binary-parser.git#with-loophole",
     "eslint": "^4.1.1",

--- a/spec/run.js
+++ b/spec/run.js
@@ -1,5 +1,5 @@
 import Jasmine from 'jasmine'
 
-var jasmine = new Jasmine()
+const jasmine = new Jasmine()
 jasmine.loadConfigFile('spec/support/jasmine.json')
 jasmine.execute()

--- a/spec/test-content-spec.js
+++ b/spec/test-content-spec.js
@@ -45,7 +45,7 @@ describe("render Foo", function () {
     bMockData = "bMock"
   })
   function renderComponent(props) {
-    props = props || {}
+    props = props || ({})
     return shallow(
       <Foo
         a={aMockData}

--- a/spec/test-content-spec.js
+++ b/spec/test-content-spec.js
@@ -15,7 +15,7 @@ import { randoFunc } from '${sampleModulePath}'
 
 describe("randoFunc", function () {
   it("works", function () {
-    var result = randoFunc();
+    const result = randoFunc();
     expect(result).to.deepEqual({})
   })
 })`
@@ -38,8 +38,8 @@ import { expect } from 'chai'
 import React from 'react'
 
 describe("render Foo", function () {
-  var aMockData;
-  var bMockData;
+  let aMockData;
+  let bMockData;
   beforeEach(function () {
     aMockData = "aMock"
     bMockData = "bMock"
@@ -53,7 +53,7 @@ describe("render Foo", function () {
         {...props} />);
   }
   it("can render", function () {
-    var result = renderComponent();
+    const result = renderComponent();
     expect(result).to.deep.equal(result)
   })
 })`

--- a/spec/tree-builders-spec.js
+++ b/spec/tree-builders-spec.js
@@ -24,7 +24,7 @@ describe('tree-builders', () => {
       const result = buildRenderFunc('Foo')
       const expected =
 `function renderComponent(props) {
-  props = props || {}
+  props = props || ({})
   return shallow(
       <Foo {...props} />);
 }`

--- a/spec/tree-builders-spec.js
+++ b/spec/tree-builders-spec.js
@@ -3,7 +3,7 @@
 import e from 'estree-builder'
 
 import {
-  vr,
+  lt,
   buildItBlock,
   buildBeforeEach,
   buildRenderFunc,
@@ -57,13 +57,13 @@ describe('tree-builders', () => {
       const result = buildBeforeEach([{
         propName: 'f',
         mockName: 'fMock',
-        mockVar: vr('fMock'),
+        mockVar: lt('fMock'),
         mockVal: propTypeToMock['func']()
       },
       {
         propName: 's',
         mockName: 'sMock',
-        mockVar: vr('sMock'),
+        mockVar: lt('sMock'),
         mockVal: e.string('sMock')
       }])
       const expected =
@@ -100,7 +100,7 @@ describe('tree-builders', () => {
 
 const cmp = (ac, exp) => {
   expect(ac).toEqual(exp)
-  for (var i = 0; i < ac.length; i++) {
+  for (let i = 0; i < ac.length; i++) {
     expect(ac[i]).toEqual(exp[i])
   }
 }


### PR DESCRIPTION
I have upgraded `estree-builder` to get access to the new funcs for `let` and `const`. I have purged these from all generated code.

This closes https://github.com/eddiesholl/atom-fancy-react/issues/42