### PR TITLE
use fat arrows for anon funcs

### DIFF
--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -8,7 +8,7 @@ import { noNulls } from './utils'
 import {
   callFn,
   dot,
-  fn,
+  arrow,
   lt,
   buildBeforeEach,
   buildRenderFunc,
@@ -146,7 +146,7 @@ const buildSuiteForClassBased = (classComponentNode, builderOptions, allNodes) =
     e.identifier('describe'),
     [
       e.string(`render ${className}`),
-      fn(
+      arrow(
         ...letForPropTypes(propTypeOutputs),
         beforeEach,
         buildRenderFunc(className, propTypeOutputs),
@@ -176,7 +176,7 @@ const buildSuiteForJsx = (exportNode, { exportName }) => {
     e.identifier('describe'),
     [
       e.string(`render ${exportName}`),
-      fn(
+      arrow(
         buildRenderFunc(exportName),
         buildItBlock('can render', [generateResult, checkResult]))
     ])
@@ -211,7 +211,7 @@ const buildSuiteForBasicFunc = (exportNode, { exportName }) => {
     e.identifier('describe'),
     [
       e.string(exportName),
-      fn(buildItBlock('works', [generateResult, checkResult]))
+      arrow(buildItBlock('works', [generateResult, checkResult]))
     ])
 
   return {

--- a/lib/tree-builders.js
+++ b/lib/tree-builders.js
@@ -10,7 +10,7 @@ export const buildBeforeEach = (propDefs) => {
     return e('=', e.id(p.mockName), p.mockVal)
   })
   return callFn('beforeEach', [
-    fn(
+    arrow(
       ...mocks
     )
   ])
@@ -45,7 +45,7 @@ ${s6}<${name}${propAssignsWithPad}{...props} />`)]))
 export const buildItBlock = (desc, body) => {
   return callFn(
     'it',
-    [e.string(desc), e.function([], body)])
+    [e.string(desc), e.arrow([], body)])
 }
 
 export const buildClass = (className, superClass, methods) => {
@@ -118,6 +118,10 @@ export const dot = (target, prop) => {
 
 export const assign = (left, right) => {
   return e('=', left, right)
+}
+
+export const arrow = (...body) => {
+  return e.arrow([], noNulls(body))
 }
 
 export const fn = (...body) => {

--- a/spec/test-content-spec.js
+++ b/spec/test-content-spec.js
@@ -13,8 +13,8 @@ const randoFuncOutput =
 `
 import { randoFunc } from '${sampleModulePath}'
 
-describe("randoFunc", function () {
-  it("works", function () {
+describe("randoFunc", () => {
+  it("works", () => {
     const result = randoFunc();
     expect(result).to.deepEqual({})
   })
@@ -37,10 +37,10 @@ import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import React from 'react'
 
-describe("render Foo", function () {
+describe("render Foo", () => {
   let aMockData;
   let bMockData;
-  beforeEach(function () {
+  beforeEach(() => {
     aMockData = "aMock"
     bMockData = "bMock"
   })
@@ -52,7 +52,7 @@ describe("render Foo", function () {
         b={bMockData}
         {...props} />);
   }
-  it("can render", function () {
+  it("can render", () => {
     const result = renderComponent();
     expect(result).to.deep.equal(result)
   })

--- a/spec/tree-builders-spec.js
+++ b/spec/tree-builders-spec.js
@@ -38,7 +38,7 @@ describe('tree-builders', () => {
     it('works', () => {
       const result = buildItBlock('desc', [e.string('body')])
       const expected =
-`it("desc", function () {
+`it("desc", () => {
   "body"
 })`
       cmp(genJs(result), expected)
@@ -49,7 +49,7 @@ describe('tree-builders', () => {
     it('works', () => {
       const result = buildBeforeEach([])
       const expected =
-`beforeEach(function () {})`
+`beforeEach(() => {})`
       cmp(genJs(result), expected)
     })
 
@@ -67,7 +67,7 @@ describe('tree-builders', () => {
         mockVal: e.string('sMock')
       }])
       const expected =
-`beforeEach(function () {
+`beforeEach(() => {
   fMock = jest.fn()
   sMock = "sMock"
 })`


### PR DESCRIPTION
This converts all the anon functions to use fat arrow syntax. This closes off the last of modernising `estree-builder` syntax https://github.com/eddiesholl/atom-fancy-react/issues/4