### PR TITLE
Disable test generation for wrapped exports

### DIFF
--- a/lib/test-content.js
+++ b/lib/test-content.js
@@ -79,7 +79,7 @@ ${namedExportSuites}`
 }
 
 const buildSuitesFor = (exportingNodes, allNodes, inputModulePath) => {
-  return exportingNodes.map(en => buildSuiteFor(en, allNodes, inputModulePath))
+  return noNulls(exportingNodes.map(en => buildSuiteFor(en, allNodes, inputModulePath)))
 }
 
 const buildSuiteFor = (exportNode, allNodes, inputModulePath) => {
@@ -89,6 +89,15 @@ const buildSuiteFor = (exportNode, allNodes, inputModulePath) => {
     isTransitiveExport ?
       searchByIdName(allNodes, exportDecl.name) :
       exportNode
+
+  // Bail out if the export is for something wrapped in a call to connect
+  // This implies its a connected component and it can't be tested
+  // This *could* be applied to anything that is a wrapped export
+  if (exportDecl.callee &&
+      exportDecl.callee.callee &&
+      exportDecl.callee.callee.name === 'connect') {
+    return
+  }
 
   // printNode(exportNode, 0)
   const varDec = searchByType(declaringNode, "VariableDeclarator")

--- a/spec/test-content-spec.js
+++ b/spec/test-content-spec.js
@@ -26,6 +26,15 @@ export class Foo extends Component {
 }
 Foo.propTypes = { a: PropTypes.string.isRequired, b: PropTypes.object }
 `
+const connectedClassInput = `
+export class Foo extends Component {
+  render() {}
+}
+Foo.propTypes = { a: PropTypes.string.isRequired, b: PropTypes.object }
+
+const mapStateToProps = () => {}
+export default connect(mapStateToProps)(Foo)
+`
 const classStaticPropsInput = `
 export class Foo extends Component {
   static propTypes = { a: PropTypes.string.isRequired, b: PropTypes.object }
@@ -78,6 +87,11 @@ describe('test-content', () => {
 
     it('works with a component class with static properties', () => {
       const result = generate(classStaticPropsInput, null, sampleModulePath)
+      expect(result.content).toEqual(classOutput)
+    })
+
+    it('works with a connected class', () => {
+      const result = generate(connectedClassInput, null, sampleModulePath)
       expect(result.content).toEqual(classOutput)
     })
   })


### PR DESCRIPTION
For connected components, the default export is typically wrapped in a call to `connect`. For any exports that look like this, just bail out and don't generate any tests.

The checking could be even more detailed, for example check if any args are transitive identifiers, but this simple solution seems to be pretty solid for now.

Fixes https://github.com/eddiesholl/atom-fancy-react/issues/52