### PR TITLE
let errors from actions bubble to default handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next
+* Issue 50 - Show error dialog if something fails during command
+
 ## 0.6.1
 * Fix: Issue 66 - Use propTypes rules to choose mock data to pass the component tests
 * Fix: Issue 64 - Generate tests does not include import statements for all exported functions

--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -46,102 +46,87 @@ class FancyReact {
   }
 
   tests() {
-    try {
-      const activeEditor = atom.workspace.getActivePaneItem()
+    const activeEditor = atom.workspace.getActivePaneItem()
 
-      const inputFilePath = activeEditor.getPath()
-      const inputText = activeEditor.getText()
-      const testFilePath = this.pathFuncs.sourceFileToTestFile(inputFilePath)
-      const inputModulePath = this.pathFuncs.sourceFileToModulePath(inputFilePath)
+    const inputFilePath = activeEditor.getPath()
+    const inputText = activeEditor.getText()
+    const testFilePath = this.pathFuncs.sourceFileToTestFile(inputFilePath)
+    const inputModulePath = this.pathFuncs.sourceFileToModulePath(inputFilePath)
 
-      if (!fs.existsSync(testFilePath)) {
-        this.pathEnv.ensureFolderExists(testFilePath)
-      }
-
-      atom.workspace.open(testFilePath).then(editor => {
-        const existingText = editor.getText()
-        const generatedTests = testContent.generate(inputText, existingText, inputModulePath)
-
-        initModulePaths(this.config.projectRoot)
-
-        const formattedContent = this.output.format(
-          generatedTests.content,
-          testFilePath)
-        editor.setText(formattedContent)
-      })
+    if (!fs.existsSync(testFilePath)) {
+      this.pathEnv.ensureFolderExists(testFilePath)
     }
-    catch (e) {
-      atom.notifications.addWarning(e.message)
-    }
+
+    atom.workspace.open(testFilePath).then(editor => {
+      const existingText = editor.getText()
+      const generatedTests = testContent.generate(inputText, existingText, inputModulePath)
+
+      initModulePaths(this.config.projectRoot)
+
+      const formattedContent = this.output.format(
+        generatedTests.content,
+        testFilePath)
+      editor.setText(formattedContent)
+    })
   }
 
   generate() {
-    try {
-      const activeEditor = atom.workspace.getActivePaneItem()
+    const activeEditor = atom.workspace.getActivePaneItem()
 
-      const inputText = activeEditor.getText()
-      const bufferPosition = activeEditor.getCursorBufferPosition()
+    const inputText = activeEditor.getText()
+    const bufferPosition = activeEditor.getCursorBufferPosition()
 
-      const result = genReact(inputText, bufferPosition)
+    const result = genReact(inputText, bufferPosition)
 
-      const componentDetails = this.pathFuncs.componentDetails(result.componentName)
+    const componentDetails = this.pathFuncs.componentDetails(result.componentName)
 
-      if (!fs.existsSync(componentDetails.folderPath)) {
-        this.pathEnv.createComponentFolder(componentDetails)
-      }
+    if (!fs.existsSync(componentDetails.folderPath)) {
+      this.pathEnv.createComponentFolder(componentDetails)
+    }
 
-      if (result.inputChanges) {
-        result.inputChanges.forEach((change, ix) => {
-          activeEditor.setCursorScreenPosition(
-            { row: change.lineNumber + ix - 1, column: 0 })
-          activeEditor.insertNewline()
-          activeEditor.moveUp(1)
-          activeEditor.insertText(change.content)
-        })
-      }
-      atom.workspace.open(componentDetails.componentPath).then(editor => {
-        const formattedContent = this.output.format(
-          result.content,
-          componentDetails.componentPath
-        )
-        editor.setText(formattedContent)
+    if (result.inputChanges) {
+      result.inputChanges.forEach((change, ix) => {
+        activeEditor.setCursorScreenPosition(
+          { row: change.lineNumber + ix - 1, column: 0 })
+        activeEditor.insertNewline()
+        activeEditor.moveUp(1)
+        activeEditor.insertText(change.content)
       })
     }
-    catch (e) {
-      atom.notifications.addWarning(e.message)
-    }
+    atom.workspace.open(componentDetails.componentPath).then(editor => {
+      const formattedContent = this.output.format(
+        result.content,
+        componentDetails.componentPath
+      )
+      editor.setText(formattedContent)
+    })
   }
 
   switch() {
-    try {
-      const activeEditor = atom.workspace.getActivePaneItem()
-      const currentFilePath = activeEditor.getPath()
-      const isCurrentFileTest = this.pathFuncs.isPathTestFile(currentFilePath)
+    const activeEditor = atom.workspace.getActivePaneItem()
+    const currentFilePath = activeEditor.getPath()
+    const isCurrentFileTest = this.pathFuncs.isPathTestFile(currentFilePath)
 
-      if (isCurrentFileTest) {
-        const sourceFilePath = this.pathFuncs.testFileToSourceFile(currentFilePath)
+    if (isCurrentFileTest) {
+      const sourceFilePath = this.pathFuncs.testFileToSourceFile(currentFilePath)
 
-        if (fs.existsSync(sourceFilePath)) {
-          atom.workspace.open(sourceFilePath)
-        }
-        else {
-          atom.notifications.addWarning(`The source file ${sourceFilePath} doesn't seem to exist :(`)
-        }
+      if (fs.existsSync(sourceFilePath)) {
+        atom.workspace.open(sourceFilePath)
       }
       else {
-        const testFilePath = this.pathFuncs.sourceFileToTestFile(currentFilePath)
-
-        if (fs.existsSync(testFilePath)) {
-          atom.workspace.open(testFilePath)
-        }
-        else {
-          // TODO We could generate here
-          atom.notifications.addWarning(`The test file ${testFilePath} doesn't seem to exist :(`)
-        }
+        atom.notifications.addWarning(`The source file ${sourceFilePath} doesn't seem to exist :(`)
       }
     }
-    catch (e) {
-      atom.notifications.addWarning(e.message)
+    else {
+      const testFilePath = this.pathFuncs.sourceFileToTestFile(currentFilePath)
+
+      if (fs.existsSync(testFilePath)) {
+        atom.workspace.open(testFilePath)
+      }
+      else {
+        // TODO We could generate here
+        atom.notifications.addWarning(`The test file ${testFilePath} doesn't seem to exist :(`)
+      }
     }
   }
 }

--- a/lib/output.js
+++ b/lib/output.js
@@ -10,9 +10,16 @@ class Output {
   }
 
   format(text, fileName) {
-    return this.linter ?
-      this.linter.format(text, fileName) :
-      text
+    try {
+      return this.linter ?
+        this.linter.format(text, fileName) :
+        text
+    }
+    catch (e) {
+      atom.notifications.addWarning(`Failed to format output: ${e.message}`)
+
+      return text
+    }
   }
 }
 


### PR DESCRIPTION
Now that the actions are fairly robust, we should stop consuming all exceptions and just let them bubble up. This will potentially allow them to be raised as github issues. The exception rate should be low enough now that this is OK.

The one exception is using eslint to format text. I don't want this to be a hard error, so it gets a dedicated try catch with warning dialog.

Addresses https://github.com/eddiesholl/atom-fancy-react/issues/50