### PR TITLE
Don't generate a new component implementation for lower case elements 

### DIFF
--- a/lib/fancy-react.js
+++ b/lib/fancy-react.js
@@ -6,7 +6,7 @@ const { loadConfigItems, buildPaths } = require('./config')
 const pathEnv = require('./path-env')
 const pathFuncs = require('./path-funcs')
 const testContent = require('./test-content')
-const genReact = require('./react-content').generate
+const generateComponent = require('./react-content').generate
 
 class FancyReact {
 
@@ -76,29 +76,34 @@ class FancyReact {
     const inputText = activeEditor.getText()
     const bufferPosition = activeEditor.getCursorBufferPosition()
 
-    const result = genReact(inputText, bufferPosition)
+    const result = generateComponent(inputText, bufferPosition)
 
-    const componentDetails = this.pathFuncs.componentDetails(result.componentName)
+    result.matchWith({
+      Ok: ({ value }) => {
+        const componentDetails = this.pathFuncs.componentDetails(value.componentName)
 
-    if (!fs.existsSync(componentDetails.folderPath)) {
-      this.pathEnv.createComponentFolder(componentDetails)
-    }
+        if (!fs.existsSync(componentDetails.folderPath)) {
+          this.pathEnv.createComponentFolder(componentDetails)
+        }
 
-    if (result.inputChanges) {
-      result.inputChanges.forEach((change, ix) => {
-        activeEditor.setCursorScreenPosition(
-          { row: change.lineNumber + ix - 1, column: 0 })
-        activeEditor.insertNewline()
-        activeEditor.moveUp(1)
-        activeEditor.insertText(change.content)
-      })
-    }
-    atom.workspace.open(componentDetails.componentPath).then(editor => {
-      const formattedContent = this.output.format(
-        result.content,
-        componentDetails.componentPath
-      )
-      editor.setText(formattedContent)
+        if (value.changesToCaller) {
+          value.changesToCaller.forEach((change, ix) => {
+            activeEditor.setCursorScreenPosition(
+              { row: change.lineNumber + ix - 1, column: 0 })
+            activeEditor.insertNewline()
+            activeEditor.moveUp(1)
+            activeEditor.insertText(change.content)
+          })
+        }
+        atom.workspace.open(componentDetails.componentPath).then(editor => {
+          const formattedContent = this.output.format(
+            value.content,
+            componentDetails.componentPath
+          )
+          editor.setText(formattedContent)
+        })
+      },
+      Error: ({ value }) => atom.notifications.addWarning(`Component generation failed: ${value}`)
     })
   }
 

--- a/lib/react-content.js
+++ b/lib/react-content.js
@@ -1,6 +1,10 @@
 'use babel'
 
 const e = require('estree-builder')
+const Result = require('folktale/result')
+
+const { ComponentGeneration } = require('./types')
+const { validComponentName } = require('./utils')
 
 import { parse } from './acorn'
 import { searchByLocationAndType } from './node-ops'
@@ -28,17 +32,20 @@ export const generate = (inputText, point) => {
   const jsxOpening = jsxBlock.openingElement
   const componentName = jsxOpening.name.name
 
-  const importStmts = generateImports(componentName)
-  const declarationStmts = generateComponents(jsxOpening)
-  const inputChanges = importNewComponent(tree.body, componentName)
+  const componentDefinitionCode = generateComponents(jsxOpening)
 
-  const ast = importStmts.concat(declarationStmts)
-  return {
-    content: genJsList(ast),
-    ast,
-    componentName,
-    inputChanges
-  }
+  return componentDefinitionCode.map((c) => {
+    const changesToCaller = importNewComponent(tree.body, componentName)
+    const importStmts = generateImports(componentName)
+    const ast = importStmts.concat(c)
+
+    return ComponentGeneration({
+      content: genJsList(ast),
+      ast,
+      componentName,
+      changesToCaller
+    })
+  })
 }
 
 export const generateImports = (componentName) => {
@@ -57,6 +64,10 @@ export const generateImports = (componentName) => {
 export const generateComponents = (jsxNode) => {
   const className = jsxNode.name.name
 
+  if (!validComponentName(className)) {
+    return Result.Error(`The element name '${className}' is not valid for a component`)
+  }
+
   const classDecl = buildClass(className, 'Component', {
     render: generateRender(className, jsxNode.attributes)
   })
@@ -64,7 +75,7 @@ export const generateComponents = (jsxNode) => {
   const defProps = generateProps(className, jsxNode.attributes)
 
   const defExport = raw(`export default ${className}`)
-  return [classDecl, defProps, defExport]
+  return Result.Ok([classDecl, defProps, defExport])
 }
 
 export const importNewComponent = (nodes, compName) => {

--- a/lib/types.js
+++ b/lib/types.js
@@ -27,7 +27,15 @@ const Paths = t.struct({
   testPath: t.String
 }, 'Paths')
 
+const ComponentGeneration = t.struct({
+  content: t.String,
+  ast: t.Object,
+  componentName: t.String,
+  changesToCaller: t.Array
+}, 'ComponentGeneration')
+
 module.exports = {
   Config,
-  Paths
+  Paths,
+  ComponentGeneration
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,3 +11,11 @@ export const mergeArrays = (...arrays) => {
 }
 
 export const pad = (thing, suffix) => thing ? ` ${thing}${suffix || ''} ` : ' '
+
+export const validComponentName = (name) => {
+  if (name.length === 0) {
+    return false
+  }
+  const first = name[0]
+  return first.toUpperCase() === first
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint": "^4.1.1",
     "eslint-plugin-jasmine": "^2.6.2",
     "estree-builder": "^1.10.0",
+    "folktale": "^2.0.1",
     "mkdirp": "^0.5.1",
     "ramda": "^0.24.0",
     "tcomb": "^3.2.22"


### PR DESCRIPTION
Drop in the folktale result object to help passing up validation style errors during component validation.

Fixes https://github.com/eddiesholl/atom-fancy-react/issues/35