### PR TITLE
ignore trimming an empty folder

### DIFF
--- a/lib/path-funcs/path-helpers.js
+++ b/lib/path-funcs/path-helpers.js
@@ -1,5 +1,7 @@
 const trimLeadingFolders = (path, folders) => {
-  if (folders.length === 0) {
+  const interestingFolders = folders.filter(Boolean)
+
+  if (interestingFolders.length === 0) {
     return {
       success: true,
       value: path
@@ -11,8 +13,8 @@ const trimLeadingFolders = (path, folders) => {
     }
   }
   else {
-    const foldersHead = folders[0]
-    const foldersTail = folders.slice(1)
+    const foldersHead = interestingFolders[0]
+    const foldersTail = interestingFolders.slice(1)
     const cleanPath = path[0] === '/' ? path.slice(1) : path
 
     const pathHead = cleanPath.slice(0, foldersHead.length)
@@ -49,7 +51,7 @@ const attachLeadingFolders = (path, folders) => {
 }
 
 module.exports = {
-  removeExtension: (path) => path.replace(/\..+$/, ''),
+  removeExtension: (path) => path.replace(/\.[^.]+$/, ''),
 
   trimLeadingFolders,
   attachLeadingFolders

--- a/spec/path-funcs/path-helpers-spec.js
+++ b/spec/path-funcs/path-helpers-spec.js
@@ -5,6 +5,11 @@ describe('removeExtension', () => {
     const result = removeExtension('/a/b.foo')
     expect(result).toEqual('/a/b')
   })
+
+  it('can only trims from the last .', () => {
+    const result = removeExtension('aaa.bbb.ccc')
+    expect(result).toEqual('aaa.bbb')
+  })
 })
 
 describe('trimLeadingFolders', () => {
@@ -24,6 +29,11 @@ describe('trimLeadingFolders', () => {
       const result = trimLeadingFolders(subject, ['a', 'b'])
       expect(result.success).toBe(true)
       expect(result.value).toEqual('/c.js')
+    })
+    it('skips an empty trim request', () => {
+      const result = trimLeadingFolders(subject, ['a', ''])
+      expect(result.success).toBe(true)
+      expect(result.value).toEqual('/b/c.js')
     })
     it('processes 3 trims', () => {
       const result = trimLeadingFolders(subject, ['a', 'b', 'c.js'])


### PR DESCRIPTION
Resolves https://github.com/eddiesholl/atom-fancy-react/issues/76

There is also a small fix to make removeExtension deal with files with multiple '.' characters